### PR TITLE
Add min-height to main app

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -7,6 +7,10 @@ select {
   font-family: Arial, Helvetica, sans-serif !important;
 }
 
+#app {
+  min-height: 80vh;
+}
+
 h3.header {
   margin-bottom: 2.5rem;
 }


### PR DESCRIPTION
Adds min-height of 80vh to `<main id="app">`

The footer will stay always at the bottom on big screens and looks normal on mobile devices.

Before:
![image](https://user-images.githubusercontent.com/16242839/124906870-cfb33600-dfe7-11eb-8137-3526173e195a.png)

After:
![image](https://user-images.githubusercontent.com/16242839/124906988-f07b8b80-dfe7-11eb-977c-d87bf3706df9.png)

Mobile after:
![image](https://user-images.githubusercontent.com/16242839/124907060-06894c00-dfe8-11eb-9947-ceac5ead1b12.png)
