### PR TITLE
Add env support

### DIFF
--- a/app/default_values.py
+++ b/app/default_values.py
@@ -1,0 +1,119 @@
+import os
+
+_prefix = 'LT_'
+
+def _get_value_str(name, default_value):
+    env_value = os.environ.get(name)
+    return default_value if env_value is None else env_value
+
+def _get_value_int(name, default_value):
+    try:
+        return int(os.environ[name])
+    except:
+        return default_value
+
+def _get_value_bool(name, default_value):
+    env_value = os.environ.get(name)
+    if env_value in ['FALSE', 'False', 'false', '0']:
+        return False
+    if env_value in ['TRUE', 'True', 'true', '1']:
+        return True
+    return default_value
+    
+def _get_value(name, default_value, value_type):
+    env_name = _prefix + name
+    if value_type == 'str':
+        return _get_value_str(env_name, default_value)
+    if value_type == 'int':
+        return _get_value_int(env_name, default_value)
+    if value_type == 'bool':
+        return _get_value_bool(env_name, default_value)
+    return default_value
+
+_default_options_objects = [
+    {
+        'name': 'HOST',
+        'default_value': '127.0.0.1',
+        'value_type': 'str'
+    },
+    {
+        'name': 'PORT',
+        'default_value': 5000,
+        'value_type': 'int'
+    },
+    {
+        'name': 'CHAR_LIMIT',
+        'default_value': -1,
+        'value_type': 'int'
+    },
+    {
+        'name': 'REQ_LIMIT',
+        'default_value': -1,
+        'value_type': 'int'
+    },
+    {
+        'name': 'DAILY_REQ_LIMIT',
+        'default_value': -1,
+        'value_type': 'int'
+    },
+    {
+        'name': 'REQ_FLOOD_THRESHOLD',
+        'default_value': -1,
+        'value_type': 'int'
+    },
+    {
+        'name': 'BATCH_LIMIT',
+        'default_value': -1,
+        'value_type': 'int'
+    },
+    {
+        'name': 'GA_ID',
+        'default_value': None,
+        'value_type': 'str'
+    },
+    {
+        'name': 'DEBUG',
+        'default_value': False,
+        'value_type': 'bool'
+    }, 
+    {
+        'name': 'SSL',
+        'default_value': None,
+        'value_type': 'bool'
+    },
+    {
+        'name': 'FRONTEND_LANGUAGE_SOURCE',
+        'default_value': 'en',
+        'value_type': 'str'
+    },
+    {
+        'name': 'FRONTEND_LANGUAGE_TARGET',
+        'default_value': 'es',
+        'value_type': 'str'
+    },
+    {
+        'name': 'FRONTEND_TIMEOUT',
+        'default_value': 500,
+        'value_type': 'int'
+    },
+    {
+        'name': 'API_KEYS',
+        'default_value': False,
+        'value_type': 'bool'
+    },
+    {
+        'name': 'REQUIRE_API_KEY_ORIGIN',
+        'default_value': '',
+        'value_type': 'str'
+    },
+    {
+        'name': 'LOAD_ONLY',
+        'default_value': None,
+        'value_type': 'str'
+    }
+]
+
+
+DEFAULT_ARGUMENTS = { obj['name']:_get_value(**obj) for obj in _default_options_objects}
+
+print(DEFAULT_ARGUMENTS)

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ def main():
     )
     parser.add_argument(
         "--daily-req-limit",
-        default=DEFARGS['DAILY_REQ_LIMI'],
+        default=DEFARGS['DAILY_REQ_LIMIT'],
         type=int,
         metavar="<number>",
         help="Set the default maximum number of requests per day per client, in addition to req-limit. (%(default)s)",

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ import sys
 import operator
 
 from app.app import create_app
+from app.default_values import DEFAULT_ARGUMENTS as DEFARGS
 
 
 def main():
@@ -10,40 +11,40 @@ def main():
         description="LibreTranslate - Free and Open Source Translation API"
     )
     parser.add_argument(
-        "--host", type=str, help="Hostname (%(default)s)", default="127.0.0.1"
+        "--host", type=str, help="Hostname (%(default)s)", default=DEFARGS['HOST']
     )
-    parser.add_argument("--port", type=int, help="Port (%(default)s)", default=5000)
+    parser.add_argument("--port", type=int, help="Port (%(default)s)", default=DEFARGS['PORT'])
     parser.add_argument(
         "--char-limit",
-        default=-1,
+        default=DEFARGS['CHAR_LIMIT'],
         type=int,
         metavar="<number of characters>",
         help="Set character limit (%(default)s)",
     )
     parser.add_argument(
         "--req-limit",
-        default=-1,
+        default=DEFARGS['REQ_LIMIT'],
         type=int,
         metavar="<number>",
         help="Set the default maximum number of requests per minute per client (%(default)s)",
     )
     parser.add_argument(
         "--daily-req-limit",
-        default=-1,
+        default=DEFARGS['DAILY_REQ_LIMI'],
         type=int,
         metavar="<number>",
         help="Set the default maximum number of requests per day per client, in addition to req-limit. (%(default)s)",
     )
     parser.add_argument(
         "--req-flood-threshold",
-        default=-1,
+        default=DEFARGS['REQ_FLOOD_THRESHOLD'],
         type=int,
         metavar="<number>",
         help="Set the maximum number of request limit offences per 4 weeks that a client can exceed before being banned. (%(default)s)",
     )
     parser.add_argument(
         "--batch-limit",
-        default=-1,
+        default=DEFARGS['BATCH_LIMIT'],
         type=int,
         metavar="<number of texts>",
         help="Set maximum number of texts to translate in a batch request (%(default)s)",
@@ -51,52 +52,53 @@ def main():
     parser.add_argument(
         "--ga-id",
         type=str,
-        default=None,
+        default=DEFARGS['GA_ID'],
         metavar="<GA ID>",
         help="Enable Google Analytics on the API client page by providing an ID (%(default)s)",
     )
     parser.add_argument(
-        "--debug", default=False, action="store_true", help="Enable debug environment"
+        "--debug", default=DEFARGS['DEBUG'], action="store_true", help="Enable debug environment"
     )
     parser.add_argument(
-        "--ssl", default=None, action="store_true", help="Whether to enable SSL"
+        "--ssl", default=DEFARGS['SSL'], action="store_true", help="Whether to enable SSL"
     )
     parser.add_argument(
         "--frontend-language-source",
         type=str,
-        default="en",
+        default=DEFARGS['FRONTEND_LANGUAGE_SOURCE'],
         metavar="<language code>",
         help="Set frontend default language - source (%(default)s)",
     )
     parser.add_argument(
         "--frontend-language-target",
         type=str,
-        default="es",
+        default=DEFARGS['FRONTEND_LANGUAGE_TARGET'],
         metavar="<language code>",
         help="Set frontend default language - target (%(default)s)",
     )
     parser.add_argument(
         "--frontend-timeout",
         type=int,
-        default=500,
+        default=DEFARGS['FRONTEND_TIMEOUT'],
         metavar="<milliseconds>",
         help="Set frontend translation timeout (%(default)s)",
     )
     parser.add_argument(
         "--api-keys",
-        default=False,
+        default=DEFARGS['API_KEYS'],
         action="store_true",
         help="Enable API keys database for per-user rate limits lookup",
     )
     parser.add_argument(
         "--require-api-key-origin",
         type=str,
-        default="",
+        default=DEFARGS['REQUIRE_API_KEY_ORIGIN'],
         help="Require use of an API key for programmatic access to the API, unless the request origin matches this domain",
     )
     parser.add_argument(
         "--load-only",
         type=operator.methodcaller("split", ","),
+        default=DEFARGS['LOAD_ONLY'],
         metavar="<comma-separated language codes>",
         help="Set available languages (ar,de,en,es,fr,ga,hi,it,ja,ko,pt,ru,zh)",
     )


### PR DESCRIPTION
In this pull request, I added an env vars layer between the cli default values and the passed args.

For instance, the default value of `HOST` is the old one (`127.0.0.1`), but if I add an env var `LT_HOST=www.ciao.com/api`, the `host` default value will be that one. If I pass both that env var and an argument `--host www.google.it/api`, the arg one wins.

This was done for each option, maintaining all the old values, this means that it is not a breakable change (unless someone has an env var with he same name)

The env var has the same uppercase-snake-case name of the cli option, but with a prefix `LT_` prepended to it (`req-flood-threshold` -> `LT_REQ_FLOOD_THRESHOLD`)

This could be for instance used on a docker-compose env file

Signed-off-by: euberdeveloper <euberdeveloper@gmail.com>