### PR TITLE
Expose require_api_key_origin in frontend settings

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -756,6 +756,9 @@ def create_app(args):
                 frontendTimeout:
                   type: integer
                   description: Frontend translation timeout
+                keyRequired:
+                  type: boolean
+                  description: Whether an API key is required.
                 suggestions:
                   type: boolean
                   description: Whether submitting suggestions is enabled.
@@ -790,6 +793,7 @@ def create_app(args):
             {
                 "charLimit": args.char_limit,
                 "frontendTimeout": args.frontend_timeout,
+                "keyRequired": bool(args.api_keys and args.require_api_key_origin),
                 "suggestions": args.suggestions,
                 "filesTranslation": not args.disable_files_translation,
                 "supportedFilesFormat": [] if args.disable_files_translation else frontend_argos_supported_files_format,


### PR DESCRIPTION
This is useful for applications that want to know beforehand if an API key is necessary before accessing the running instance.

This is necessary for me as a part of adding proper support for LibreTranslate API keys in [Dialect](https://github.com/dialect-app/dialect).