### PR TITLE
Properly escape data in the request code

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -145,9 +145,9 @@ document.addEventListener('DOMContentLoaded', function(){
                 return ['const res = await fetch("' + this.BaseUrl + '/translate", {',
                     '	method: "POST",',
                     '	body: JSON.stringify({',
-                    '		q: "' + this.$options.filters.escape(this.inputText) + '",',
-                    '		source: "' + this.$options.filters.escape(this.sourceLang) + '",',
-                    '		target: "' + this.$options.filters.escape(this.targetLang) + '",',
+                    '		q: ' + this.$options.filters.escape(this.inputText) + ',',
+                    '		source: ' + this.$options.filters.escape(this.sourceLang) + ',',
+                    '		target: ' + this.$options.filters.escape(this.targetLang) + ',',
                     '		format: "' + (this.isHtml ? "html" : "text") + '"',
                     '	}),',
                     '	headers: { "Content-Type": "application/json" }',
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', function(){
         },
         filters: {
             escape: function(v){
-                return v.replace('"', '\\\"');
+                return JSON.stringify(v);
             },
             highlight: function(v){
                 return Prism.highlight(v, Prism.languages.javascript, 'javascript');


### PR DESCRIPTION
It was only escaping the first quote, all other quotes and other characters that require to be escaped (like line breaks) were not being escaped. JSON.stringify is a good function to handle this.

Calling `this.$options.filters.escape` looks weird to me, I would just call `JSON.stringify` directly or, if a more complex escape logic was needed, move this function to a method so it can be called by `this.escape`. By the way, filters were removed in Vue 3. I kept the current `filter` call, but consider changing it in future.