### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+curly_bracket_next_line = false
+spaces_around_operators = true
+
+[*.{js,py}]
+indent_size = 4
+
+[*.{js,ts}]
+quote_type = double
+
+[*.{markdown,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Wanted to contibute something, but editor settings are getting in the way. ^-^'

Adds an [EditorConfig](https://editorconfig.org/) file, so contributors can use consistent code styles with the rest of the project.
This makes it more convenient to work on the project when a developer's editor settings aren't the same as yours.

EditorConfig is a widely supported format that code editors use to override user preferences to adhere to project conventions.
The current settings are based on what I can see from exploring the repository, you may wish to modify the rules.