### PR TITLE
app: Fail when giving invalid API keys

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,18 +3,20 @@ import os
 import tempfile
 import uuid
 from functools import wraps
+from html import unescape
 
 import argostranslatefiles
 from argostranslatefiles import get_supported_formats
-from flask import Flask, abort, jsonify, render_template, request, url_for, send_file
+from flask import (Flask, abort, jsonify, render_template, request, send_file,
+                   url_for)
 from flask_swagger import swagger
 from flask_swagger_ui import get_swaggerui_blueprint
 from translatehtml import translate_html
 from werkzeug.utils import secure_filename
-from html import unescape
 
 from app import flood, remove_translated_files, security
 from app.language import detect_languages, transliterate
+
 from .api_keys import Database
 from .suggestions import Database as SuggestionsDatabase
 
@@ -139,7 +141,6 @@ def create_app(args):
             frontend_argos_language_target = languages[1]
         else:
             frontend_argos_language_target = languages[0]
-
 
     api_keys_db = None
 

--- a/app/app.py
+++ b/app/app.py
@@ -174,11 +174,19 @@ def create_app(args):
                 if flood.has_violation(ip):
                     flood.decrease(ip)
 
-            if args.api_keys and args.require_api_key_origin:
+            if args.api_keys:
                 ak = get_req_api_key()
-
                 if (
-                        api_keys_db.lookup(ak) is None and request.headers.get("Origin") != args.require_api_key_origin
+                    ak and api_keys_db.lookup(ak) is None
+                ):
+                    abort(
+                        403,
+                        description="Invalid API key",
+                    )
+                elif (
+                    args.require_api_key_origin
+                    and api_keys_db.lookup(ak) is None
+                    and request.headers.get("Origin") != args.require_api_key_origin
                 ):
                     abort(
                         403,

--- a/app/default_values.py
+++ b/app/default_values.py
@@ -2,15 +2,18 @@ import os
 
 _prefix = 'LT_'
 
+
 def _get_value_str(name, default_value):
     env_value = os.environ.get(name)
     return default_value if env_value is None else env_value
+
 
 def _get_value_int(name, default_value):
     try:
         return int(os.environ[name])
     except:
         return default_value
+
 
 def _get_value_bool(name, default_value):
     env_value = os.environ.get(name)
@@ -19,6 +22,7 @@ def _get_value_bool(name, default_value):
     if env_value in ['TRUE', 'True', 'true', '1']:
         return True
     return default_value
+
 
 def _get_value(name, default_value, value_type):
     env_name = _prefix + name
@@ -29,6 +33,7 @@ def _get_value(name, default_value, value_type):
     if value_type == 'bool':
         return _get_value_bool(env_name, default_value)
     return default_value
+
 
 _default_options_objects = [
     {
@@ -114,7 +119,7 @@ _default_options_objects = [
     {
         'name': 'SUGGESTIONS',
         'default_value': False,
-        'value_type':  'bool'
+        'value_type': 'bool'
     },
     {
         'name': 'DISABLE_FILES_TRANSLATION',
@@ -129,4 +134,4 @@ _default_options_objects = [
 ]
 
 
-DEFAULT_ARGUMENTS = { obj['name']:_get_value(**obj) for obj in _default_options_objects}
+DEFAULT_ARGUMENTS = {obj['name']: _get_value(**obj) for obj in _default_options_objects}

--- a/app/flood.py
+++ b/app/flood.py
@@ -22,6 +22,7 @@ def forgive_banned():
     for ip in clear_list:
         del banned[ip]
 
+
 def setup(violations_threshold=100):
     global active
     global threshold

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import argparse
-import sys
 import operator
+import sys
 
 from app.app import create_app
 from app.default_values import DEFAULT_ARGUMENTS as DEFARGS

--- a/app/security.py
+++ b/app/security.py
@@ -1,7 +1,9 @@
 import os
 
+
 class SuspiciousFileOperation(Exception):
     pass
+
 
 def path_traversal_check(unsafe_path, known_safe_path):
     known_safe_path = os.path.abspath(known_safe_path)

--- a/app/suggestions.py
+++ b/app/suggestions.py
@@ -1,5 +1,4 @@
 import sqlite3
-import uuid
 
 from expiringdict import ExpiringDict
 


### PR DESCRIPTION
When an API key is passed, fail in the case of an invalid API key even if an API key is not required. This allows the user to know that the API key is invalid. Otherwise, they work under the assumption that the API key is correct, even though it is not.