### PR TITLE
Fix language detection error

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -102,7 +102,7 @@ def create_app(args):
 
     boot(args.load_only)
 
-    from app.language import languages
+    from app.language import load_languages
 
     app = Flask(__name__)
 
@@ -111,6 +111,7 @@ def create_app(args):
 
     if not args.disable_files_translation:
         remove_translated_files.setup(get_upload_dir())
+    languages = load_languages()
 
     # Map userdefined frontend languages to argos language object.
     if args.frontend_language_source == "auto":

--- a/app/language.py
+++ b/app/language.py
@@ -4,11 +4,11 @@ from argostranslate import translate
 from polyglot.detect.base import Detector, UnknownLanguage
 from polyglot.transliteration.base import Transliterator
 
-languages = translate.load_installed_languages()
 
 
-__lang_codes = [l.code for l in languages]
-
+def load_languages():
+    languages = translate.load_installed_languages()
+    return languages
 
 def detect_languages(text):
     # detect batch processing
@@ -31,6 +31,10 @@ def detect_languages(text):
 
     # total read bytes of the provided text
     text_length_total = sum(c.text_length for c in candidates)
+
+    # Load language codes
+    languages = load_languages()
+    __lang_codes = [l.code for l in languages]
 
     # only use candidates that are supported by argostranslate
     candidate_langs = list(


### PR DESCRIPTION
This closes issue #217 (and #148 as well, which references this exact same issue).

The root cause was load_installed_languages() of argostranslate being called at the top of the file instead of inside a function, this caused the list of installed languages to incorrectly be returned as an empty list.

This commit moves the call inside a function.