### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py text eol=lf


### PR DESCRIPTION
PR for #227.

Just one file has CRLF endings and it's not related to the issue.
```
± % find . -not -type d -exec file "{}" ";" | grep CRLF
./app/static/css/materialize.min.css: ASCII text, with very long lines, with CRLF, CR, LF line terminators
```

`docker-compose build` works fine in Linux, so this must be related to Windows with incorrect or missing `core.autocrlf`.

I agree with @eisenwinter, adding `.gitattributes` should solve the issue.