### PR TITLE
Readme api examples, mirror update

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ URL |API Key Required|Payment Link|Cost
 [translate.api.skitzen.com](https://translate.api.skitzen.com/)|-|-
 [libretranslate.pussthecat.org](https://libretranslate.pussthecat.org/)|-|-
 [translate.fortytwo-it.com](https://translate.fortytwo-it.com/)|-|-
+[translate.terraprint.co](https://translate.terraprint.co/)|-|-
 
 ## Adding New Languages
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Response:
 
 ```javascript
 {
+    "detectedLanguage": {
+        "confidence": 83,
+        "language": "it"
+    },
     "translatedText": "Bye!"
 }
 ```


### PR DESCRIPTION
I updated the API Examples section to show the "detectedLanguage" object returned for auto detect source language requests. I also added my mirror site [translate.terraprint.co](https://translate.terraprint.co) to the Mirrors table