### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,8 @@ Remove `#` on the ErrorLog and CustomLog lines to log requests.
     
     ProxyPass / http://127.0.0.1:5000/
     ProxyPassReverse / http://127.0.0.1:5000/
-
+    ProxyPreserveHost On
+   
     SSLEngine on
     SSLCertificateFile /etc/letsencrypt/live/[YOUR_DOMAIN]/fullchain.pem
     SSLCertificateKeyFile /etc/letsencrypt/live/[YOUR_DOMAIN]/privkey.pem


### PR DESCRIPTION
File translation via Apache proxy needs "ProxyPreserveHost On", which is "Off" on some distributions (RHEL8 for instance). Else window.location.host will point to the container IP instead of the host.