### PR TITLE
Add CUDA docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ docker-compose up -d --build
 
 > Feel free to change the [`docker-compose.yml`](https://github.com/LibreTranslate/LibreTranslate/blob/main/docker-compose.yml) file to adapt it to your deployment needs, or use an extra `docker-compose.prod.yml` file for your deployment configuration.
 
+### CUDA
+
+You can use hardware acceleration to speed up translations on a GPU machine with CUDA 11.2 and [nvidia-docker](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed.
+
+Run this version with:
+
+```bash
+docker-compose -f docker-compose.cuda.yml up -d --build
+```
+
 ## Arguments
 
 | Argument                    | Description                                                                                                 | Default              | Env. name                    |

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  libretranslate-cuda:
+    container_name: libretranslate-cuda
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.cuda
+    restart: unless-stopped
+    ports:
+      - 5000:5000
+    command: --gpus all

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,37 @@
+FROM nvidia/cuda:11.2.2-devel-ubuntu20.04
+
+ENV ARGOS_DEVICE_TYPE cuda
+ARG with_models=true
+ARG models=
+
+WORKDIR /app
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get -qqq install --no-install-recommends -y libicu-dev libaspell-dev libcairo2 libcairo2-dev pkg-config gcc g++ python3.8-dev python3-pip libpython3.8-dev\
+    && apt-get clean \
+    && rm -rf /var/lib/apt
+
+RUN pip3 install --upgrade pip
+
+COPY . .
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN if [ "$with_models" = "true" ]; then  \
+    # install only the dependencies first
+    pip3 install -e .;  \
+    # initialize the language models
+    if [ ! -z "$models" ]; then \
+    ./install_models.py --load_only_lang_codes "$models";   \
+    else \
+    ./install_models.py;  \
+    fi \
+    fi
+
+# Install package from source code
+RUN pip3 install . \
+    && pip3 cache purge
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib:/usr/local/cuda/lib64
+EXPOSE 5000
+ENTRYPOINT [ "libretranslate", "--host", "0.0.0.0" ]


### PR DESCRIPTION
Hi,

I noticed that I could get significantly better translation performance if I used the hardware acceleration supported by argos and ctranslate. 
This PR adds a dockerfile for a container that will utilize that functionality and adds information about how to use it to the docs.

Let me know what you think. I'm happy to make any needed changes.

Thanks,
Jon