### PR TITLE
fix: fix race condition in settings and langs

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -39,14 +39,17 @@ document.addEventListener('DOMContentLoaded', function(){
             filesTranslation: true,
             frontendTimeout: 500
         },
-        mounted: function(){
-            var self = this;
-            var requestSettings = new XMLHttpRequest();
-            requestSettings.open('GET', BaseUrl + '/frontend/settings', true);
+        mounted: function() {
+            const self = this;
 
-            requestSettings.onload = function() {
+            const settingsRequest = new XMLHttpRequest();
+            settingsRequest.open("GET", BaseUrl + "/frontend/settings", true);
+
+            const langsRequest = new XMLHttpRequest();
+            langsRequest.open("GET", BaseUrl + "/languages", true);
+
+            settingsRequest.onload = function() {
                 if (this.status >= 200 && this.status < 400) {
-                    // Success!
                     self.settings = JSON.parse(this.response);
                     self.sourceLang = self.settings.language.source.code;
                     self.targetLang = self.settings.language.target.code;
@@ -55,74 +58,42 @@ document.addEventListener('DOMContentLoaded', function(){
                     self.supportedFilesFormat = self.settings.supportedFilesFormat;
                     self.filesTranslation = self.settings.filesTranslation;
                     self.frontendTimeout = self.settings.frontendTimeout;
-                }else {
+
+                    if (langsRequest.response) {
+                        handleLangsResponse(self, langsRequest);
+                    } else {
+                        langsRequest.onload = function() {
+                            handleLangsResponse(self, this);
+                        }
+                    }
+                } else {
                     self.error = "Cannot load /frontend/settings";
                     self.loading = false;
                 }
             };
 
-            requestSettings.onerror = function() {
+            settingsRequest.onerror = function() {
                 self.error = "Error while calling /frontend/settings";
                 self.loading = false;
             };
 
-            requestSettings.send();
-
-            var requestLanguages = new XMLHttpRequest();
-            requestLanguages.open('GET', BaseUrl + '/languages', true);
-
-            requestLanguages.onload = function() {
-                if (this.status >= 200 && this.status < 400) {
-                    // Success!
-                    self.langs = JSON.parse(this.response);
-                    self.langs.push({ name: 'Auto Detect (Experimental)', code: 'auto' })
-                    if (self.langs.length === 0){
-                        self.loading = false;
-                        self.error = "No languages available. Did you install the models correctly?"
-                        return;
-                    }
-
-                    const sourceLanguage = self.langs.find(l => l.code === self.getQueryParam('source'))
-                    const isSourceAuto = !sourceLanguage && self.getQueryParam('source') === "auto"
-                    const targetLanguage = self.langs.find(l => l.code === self.getQueryParam('target'))
-
-                    if (sourceLanguage || isSourceAuto) {
-                        self.sourceLang = isSourceAuto ? "auto" : sourceLanguage.code
-                    }
-
-                    if (targetLanguage) {
-                        self.targetLang = targetLanguage.code
-                    }
-
-                    const defaultText = self.getQueryParam('q')
-
-                    if(defaultText) {
-                        self.inputText = decodeURI(defaultText)
-                    }
-
-                    self.loading = false;
-                } else {
-                    self.error = "Cannot load /languages";
-                    self.loading = false;
-                }
-            };
-
-            requestLanguages.onerror = function() {
+            langsRequest.onerror = function() {
                 self.error = "Error while calling /languages";
                 self.loading = false;
             };
 
-            requestLanguages.send();
+            settingsRequest.send();
+            langsRequest.send();
         },
         updated: function(){
             M.FormSelect.init(this.$refs.sourceLangDropdown);
             M.FormSelect.init(this.$refs.targetLangDropdown);
-            
+
             if (this.$refs.inputTextarea){
                 if (this.inputText === ""){
                     this.$refs.inputTextarea.style.height = this.inputTextareaHeight + "px";
                     this.$refs.translatedTextarea.style.height = this.inputTextareaHeight + "px";
-                }else{
+                } else{
                     this.$refs.inputTextarea.style.height = this.$refs.translatedTextarea.style.height = "1px";
                     this.$refs.inputTextarea.style.height = Math.max(this.inputTextareaHeight, this.$refs.inputTextarea.scrollHeight + 32) + "px";
                     this.$refs.translatedTextarea.style.height = Math.max(this.inputTextareaHeight, this.$refs.translatedTextarea.scrollHeight + 32) + "px";
@@ -136,28 +107,12 @@ document.addEventListener('DOMContentLoaded', function(){
             // Update "selected" attribute (to overcome a vue.js limitation)
             // but properly display checkmarks on supported browsers.
             // Also change the <select> width value depending on the <option> length
-            if (this.$refs.sourceLangDropdown){
-                for (var i = 0; i < this.$refs.sourceLangDropdown.children.length; i++){
-                    var el = this.$refs.sourceLangDropdown.children[i];
-                    if (el.value === this.sourceLang){
-                        el.setAttribute('selected', '');
-                        this.$refs.sourceLangDropdown.style.width = getTextWidth(el.text) + 24 + 'px';
-                    }else{
-                        el.removeAttribute('selected');
-                    }
-                }
+            if (this.$refs.sourceLangDropdown) {
+                updateSelectedAttribute(this.$refs.sourceLangDropdown, this.sourceLang);
             }
 
-            if (this.$refs.targetLangDropdown){
-                for (var i = 0; i < this.$refs.targetLangDropdown.children.length; i++){
-                    var el = this.$refs.targetLangDropdown.children[i];
-                    if (el.value === this.targetLang){
-                        el.setAttribute('selected', '');
-                        this.$refs.targetLangDropdown.style.width = getTextWidth(el.text) + 24 + 'px';
-                    }else{
-                        el.removeAttribute('selected');
-                    }
-                }
+            if (this.$refs.targetLangDropdown) {
+                updateSelectedAttribute(this.$refs.targetLangDropdown, this.targetLang);
             }
         },
         computed: {
@@ -267,10 +222,10 @@ document.addEventListener('DOMContentLoaded', function(){
                                 self.translatedText = res.translatedText;
                                 self.loadingTranslation = false;
                                 self.output = JSON.stringify(res, null, 4);
-                            }else{
+                            } else{
                                 throw new Error(res.error || "Unknown error");
                             }
-                        }catch(e){
+                        } catch (e) {
                             self.error = e.message;
                             self.loadingTranslation = false;
                         }
@@ -422,8 +377,61 @@ document.addEventListener('DOMContentLoaded', function(){
             }
         }
     });
-
 });
+
+/**
+ * @param {object} self
+ * @param {XMLHttpRequest} response
+ */
+function handleLangsResponse(self, response) {
+    if (response.status >= 200 && response.status < 400) {
+        self.langs = JSON.parse(response.response);
+
+        if (self.langs.length === 0){
+            self.loading = false;
+            self.error = "No languages available. Did you install the models correctly?"
+            return;
+        }
+
+        self.langs.push({ name: "Auto Detect (Experimental)", code: "auto" })
+
+        const sourceLanguage = self.langs.find(l => l.code === self.getQueryParam("source"))
+        const targetLanguage = self.langs.find(l => l.code === self.getQueryParam("target"))
+
+        if (sourceLanguage) {
+            self.sourceLang = sourceLanguage.code
+        }
+
+        if (targetLanguage) {
+            self.targetLang = targetLanguage.code
+        }
+
+        const defaultText = self.getQueryParam("q")
+
+        if (defaultText) {
+            self.inputText = decodeURI(defaultText)
+        }
+    } else {
+        self.error = "Cannot load /languages";
+    }
+
+    self.loading = false;
+}
+
+/**
+ * @param {object} langDropdown
+ * @param {string} lang
+ */
+function updateSelectedAttribute(langDropdown, lang) {
+    for (const child of langDropdown.children) {
+        if (child.value === lang){
+            child.setAttribute('selected', '');
+            langDropdown.style.width = getTextWidth(child.text) + 24 + 'px';
+        } else{
+            child.removeAttribute('selected');
+        }
+    }
+}
 
 function getTextWidth(text) {
     var canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement("canvas"));


### PR DESCRIPTION
This is a duplicate PR of https://github.com/LibreTranslate/LibreTranslate/pull/276 with a different approach.

This one doesn't use `fetch` or `async`.

Basically we do both requests at the same time, then we check if `langsRequest.response` is set. If it is, that means the request had finished so we just pass that, but if not then we add the `onload` handler.

We can't just depend on `onload` here because if it's outside (like before) then it might execute first which causes the issue.

If we add `onload` in the handler for `settingsRequest`, it won't trigger if the request is finished before the `onload` handler is added.

---

I ran into a problem on the website where the `source` and `target` in the query parameters would be overridden by the default settings sometimes.

It's because of a race condition with both the `/frontend/settings` and `/languages` requests modifying the same variables when they finish.

Sometimes `/languages` will finish first, which has the handling for the query parameters. Then when the `/frontend/settings` request finished, it'd remove the user-configured source and target.

This resolves the issue by still doing both requests asynchronously, but we stall the handling of the `/languages` endpoint until the `/frontend/settings` request has been handled.

---

On the side this makes some other changes:
* Formatting
* Replace the basically duplicate code with a single function with parameters.
* Moves `self.langs.push({ name: 'Auto Detect (Experimental)', code: 'auto' })` to _below_ the check for the number of languages. Before there could never be 0 languages because the `auto` language was pushed into the array before the check.
* Removes the check for `isSourceAuto`, because an extra language is added which already has the code `auto`, this was already handled.

---

Closes https://github.com/LibreTranslate/LibreTranslate/pull/276