### PR TITLE
Expand CUDA Support to more GPUs

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -18,6 +18,8 @@ COPY . .
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+RUN pip3 install torch==1.12.0+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+
 RUN if [ "$with_models" = "true" ]; then  \
     # install only the dependencies first
     pip3 install -e .;  \
@@ -32,6 +34,10 @@ RUN if [ "$with_models" = "true" ]; then  \
 # Install package from source code
 RUN pip3 install . \
     && pip3 cache purge
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib:/usr/local/cuda/lib64
+
+# Depending on your cuda install you may need to uncomment this line to allow the container to access the cuda libraries
+# See: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions
+# ENV LD_LIBRARY_PATH=/usr/local/cuda/lib:/usr/local/cuda/lib64
+
 EXPOSE 5000
 ENTRYPOINT [ "libretranslate", "--host", "0.0.0.0" ]


### PR DESCRIPTION
Hi,

After my last PR I noticed that the container would fail to translate on some GPU types.
Specifically, it would fail with:
```
{GPU} with CUDA capability {sm_**} is not compatible with the current PyTorch installation. 
The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70.
```

This is because one of the other package requirements installs the default version of PyTorch, which is only setup for some GPUs.
This change explicitly installs a CUDA PyTorch version which allows for more GPUs to be supported.

See also: https://discuss.pytorch.org/t/need-help-trouble-with-cuda-capability-sm-86/120235

While I haven't tried all of the GPUs, I was able to get this running on an A10 GPU.

A list of GPUs and their compute capability versions can be found in the Nvidia documentation: https://developer.nvidia.com/cuda-gpus

Let me know what you think, I'm happy to make any needed changes.

Thanks,
Jon