### PR TITLE
Add --api-keys-db-path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ docker-compose up -d --build
 
 > Feel free to change the [`docker-compose.yml`](https://github.com/LibreTranslate/LibreTranslate/blob/main/docker-compose.yml) file to adapt it to your deployment needs, or use an extra `docker-compose.prod.yml` file for your deployment configuration.
 
+> The models are stored inside the container under `/root/.local/share` and `/root/.local/cache`. Feel free to use volumes if you do not want to redownload the models when the container is destroyed. Be aware that this will prevent the models from being updated!
+
 ### CUDA
 
 You can use hardware acceleration to speed up translations on a GPU machine with CUDA 11.2 and [nvidia-docker](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed.
@@ -190,6 +192,7 @@ docker-compose -f docker-compose.cuda.yml up -d --build
 | --frontend-language-target  | Set frontend default language - target                                                                      | `es`          | LT_FRONTEND_LANGUAGE_TARGET  |
 | --frontend-timeout          | Set frontend translation timeout                                                                            | `500`         | LT_FRONTEND_TIMEOUT          |
 | --api-keys                  | Enable API keys database for per-user rate limits lookup                                                    | `Don't use API keys` | LT_API_KEYS                  |
+| --api-keys-db-path          | Use a specific path inside the container for the local database. Can be absolute or relative                | `api_keys.db`                      | LT_API_KEYS_DB_PATH          |
 | --api-keys-remote           | Use this remote endpoint to query for valid API keys instead of using the local database                    | `Use local API key database` | LT_API_KEYS_REMOTE                  |
 | --get-api-key-link          | Show a link in the UI where to direct users to get an API key                                               | `Don't show a link` | LT_GET_API_KEY_LINK                  |
 | --require-api-key-origin    | Require use of an API key for programmatic access to the API, unless the request origin matches this domain | `No restrictions on domain origin` | LT_REQUIRE_API_KEY_ORIGIN    |
@@ -222,7 +225,7 @@ See ["LibreTranslate: your own translation service on Kubernetes" by JM Robles](
 
 LibreTranslate supports per-user limit quotas, e.g. you can issue API keys to users so that they can enjoy higher requests limits per minute (if you also set `--req-limit`). By default all users are rate-limited based on `--req-limit`, but passing an optional `api_key` parameter to the REST endpoints allows a user to enjoy higher request limits.
 
-To use API keys simply start LibreTranslate with the `--api-keys` option.
+To use API keys simply start LibreTranslate with the `--api-keys` option. If you modified the API keys database path with the option `--api-keys-db-path`, you must specify the path with the same argument flag when using the `ltmanage keys` command. 
 
 ### Add New Keys
 
@@ -230,6 +233,11 @@ To issue a new API key with 120 requests per minute limits:
 
 ```bash
 ltmanage keys add 120
+```
+
+If you changed the API keys database path:
+```bash
+ltmanage keys --api-keys-db-path path/to/db/dbName.db add 120
 ```
 
 ### Remove Keys

--- a/app/api_keys.py
+++ b/app/api_keys.py
@@ -1,13 +1,18 @@
+import os
 import sqlite3
 import uuid
 import requests
 from expiringdict import ExpiringDict
+from app.default_values import DEFAULT_ARGUMENTS as DEFARGS
 
-DEFAULT_DB_PATH = "api_keys.db"
+DEFAULT_DB_PATH = DEFARGS['API_KEYS_DB_PATH']
 
 
 class Database:
     def __init__(self, db_path=DEFAULT_DB_PATH, max_cache_len=1000, max_cache_age=30):
+        db_dir = os.path.dirname(db_path)
+        if not db_dir == "" and not os.path.exists(db_dir):
+            os.makedirs(db_dir)
         self.db_path = db_path
         self.cache = ExpiringDict(max_len=max_cache_len, max_age_seconds=max_cache_age)
 

--- a/app/app.py
+++ b/app/app.py
@@ -151,7 +151,7 @@ def create_app(args):
             if args.api_keys_remote:
                 api_keys_db = RemoteDatabase(args.api_keys_remote)
             else:
-                api_keys_db = Database()
+                api_keys_db = Database(args.api_keys_db_path)
 
         from flask_limiter import Limiter
 

--- a/app/default_values.py
+++ b/app/default_values.py
@@ -107,6 +107,11 @@ _default_options_objects = [
         'value_type': 'bool'
     },
     {
+        'name': 'API_KEYS_DB_PATH',
+        'default_value': 'api_keys.db',
+        'value_type': 'str'
+    },
+    {
         'name': 'API_KEYS_REMOTE',
         'default_value': '',
         'value_type': 'str'

--- a/app/main.py
+++ b/app/main.py
@@ -90,6 +90,12 @@ def get_args():
         help="Enable API keys database for per-user rate limits lookup",
     )
     parser.add_argument(
+        "--api-keys-db-path",
+        default=DEFARGS['API_KEYS_DB_PATH'],
+        type=str,
+        help="Use a specific path inside the container for the local database. Can be absolute or relative (%(default)s)",
+    )
+    parser.add_argument(
         "--api-keys-remote",
         default=DEFARGS['API_KEYS_REMOTE'],
         type=str,

--- a/app/manage.py
+++ b/app/manage.py
@@ -1,6 +1,8 @@
 import argparse
+import os
 
 from app.api_keys import Database
+from app.default_values import DEFAULT_ARGUMENTS as DEFARGS
 
 
 def manage():
@@ -10,6 +12,12 @@ def manage():
     )
 
     keys_parser = subparsers.add_parser("keys", help="Manage API keys database")
+    keys_parser.add_argument(
+        "--api-keys-db-path",
+        default=DEFARGS['API_KEYS_DB_PATH'],
+        type=str,
+        help="Use a specific path inside the container for the local database",
+    )
     keys_subparser = keys_parser.add_subparsers(
         help="", dest="sub_command", title="Command List"
     )
@@ -30,7 +38,10 @@ def manage():
     args = parser.parse_args()
 
     if args.command == "keys":
-        db = Database()
+        if not os.path.exists(args.api_keys_db_path):
+            print("No such database: %s" % args.api_keys_db_path)
+            exit(1)
+        db = Database(args.api_keys_db_path)
         if args.sub_command is None:
             # Print keys
             keys = db.all()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,12 @@ services:
     ports:
       - 5000:5000
     ## Uncomment above command and define your args if necessary
-    # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500 
+    # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500
+    ## Uncomment this section and the `volumes` section if you want to backup your API keys
+    # environment:
+    #   - LT_API_KEYS_DB_PATH=/app/db/api_keys.db # Same result as `db/api_keys.db` or `./db/api_keys.db`
+    # volumes:
+    #   - libretranslate_api_keys:/app/db/api_keys.db
+
+# volumes:
+#   libretranslate_api_keys:


### PR DESCRIPTION
# Issue
The API keys database is currently directly under `/app`. This make it hard to manage it with docker volumes without targeting the whole `/app`: 

Targeting direclty the `api_keys.db` file would be bound to fail:
> The bind-mount is based on inode on Linux. Most of the time, when we change/edit a file, the editor will create a new inode and replace the old file with the new file. In this case, the bind-mount is still on the old file and the container do not see the change. ([From a docker forum post](https://forums.docker.com/t/sharing-a-single-file-via-a-volume-mount-does-not-work-as-expected/57088/3))

# What does this PR ?
Create a optional argument `--api-keys-db-path` to choose a path inside the container to store the database.

The default value is the previous value `api_keys.db` to ensure compatibility with currently deployed instances.

# How was it tested ?
I tried to run the docker without the argument, with absolute path (`/app/db/api_keys.db` and `/root/.local/db`), a relative path (`./db/api_keys_different_name.db` and `db/api_keys.db`), and relative path without folder (`api_keys.db`, `./api_keys.db` and `different_name.db`) with the command
```bash
docker run -it -p 5000:5000 -v libretranslate_models:/root/.local libretranslate --api-keys --req-limit 2 --api-keys-db-path <path>
```

Each time I checked that the route `/translate` was working with and without an API key.



It is my first time contributing to an open project, I'm sorry if I missed something (such as a PR template or some guidelines), feel free to request changes is something is bothering you :)