### PR TITLE
Non-root User for Dockerfile and Multi-Stage Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.8.12-slim-bullseye as builder
 
-ARG with_models=false
-ARG models=
-
 WORKDIR /app
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -24,11 +21,14 @@ RUN ./venv/bin/pip install . \
 
 FROM python:3.8.12-slim-bullseye
 
+ARG with_models=false
+ARG models=
+
 RUN addgroup --system --gid 1032 libretranslate && adduser --system --uid 1032 libretranslate
 RUN apt-get update -qq && apt-get -qqq install --no-install-recommends -y libicu67 && apt-get clean && rm -rf /var/lib/apt
 USER libretranslate
 
-COPY --from=builder --chown=libretranslate:libretranslate /app /app
+COPY --from=builder --chown=1032:1032 /app /app
 WORKDIR /app
 
 RUN if [ "$with_models" = "true" ]; then  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,21 +17,9 @@ RUN python -mvenv venv && ./venv/bin/pip install --upgrade pip
 
 COPY . .
 
-
-RUN if [ "$with_models" = "true" ]; then  \
-  # install only the dependencies first
-  ./venv/bin/pip install -e .;  \
-  # initialize the language models
-  if [ ! -z "$models" ]; then \
-  ./venv/bin/python install_models.py --load_only_lang_codes "$models";   \
-  else \
-  ./venv/bin/python install_models.py;  \
-  fi \
-  fi
 # Install package from source code
 RUN ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
-
 
 
 FROM python:3.8.12-slim-bullseye
@@ -42,6 +30,15 @@ USER libretranslate
 
 COPY --from=builder --chown=libretranslate:libretranslate /app /app
 WORKDIR /app
+
+RUN if [ "$with_models" = "true" ]; then  \
+  # initialize the language models
+  if [ ! -z "$models" ]; then \
+  ./venv/bin/python install_models.py --load_only_lang_codes "$models";   \
+  else \
+  ./venv/bin/python install_models.py;  \
+  fi \
+  fi
 
 EXPOSE 5000
 ENTRYPOINT [ "./venv/bin/libretranslate", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.12-slim-bullseye as builder
+FROM python:3.8.14-slim-bullseye as builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 
 
-FROM python:3.8.12-slim-bullseye
+FROM python:3.8.14-slim-bullseye
 
 ARG with_models=false
 ARG models=


### PR DESCRIPTION
Updates the Dockerfile to improve security and image size.
In particular, this allows the image to be run under the "restricted" pod security standard in Kubernetes.

* Creates and installs under a new user, `libretranslate` to avoid requiring root
* Splits the Dockerfile into a multistage to to avoid keeping dev tools in the final image
* Updates the base image to 3.8.14