### PR TITLE
Support for persistent request limit storage via redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ docker-compose -f docker-compose.cuda.yml up -d --build
 | --port                      | Set port to bind the server to                                                                              | `5000`               | LT_PORT                      |
 | --char-limit                | Set character limit                                                                                         | `No limit`               | LT_CHAR_LIMIT                |
 | --req-limit                 | Set maximum number of requests per minute per client                                                        | `No limit`               | LT_REQ_LIMIT                 |
+| --req-limit-storage         | Storage URI to use for request limit data storage. See [Flask Limiter](https://flask-limiter.readthedocs.io/en/stable/configuration.html) | `memory://` | LT_REQ_STORAGE |
 | --batch-limit               | Set maximum number of texts to translate in a batch request                                                 | `No limit`               | LT_BATCH_LIMIT               |
 | --ga-id                     | Enable Google Analytics on the API client page by providing an ID                                           | `No tracking`               | LT_GA_ID                     |
 | --debug                     | Enable debug environment                                                                                    | `False`           | LT_DEBUG                     |

--- a/app/app.py
+++ b/app/app.py
@@ -161,6 +161,7 @@ def create_app(args):
             default_limits=get_routes_limits(
                 args.req_limit, args.daily_req_limit, api_keys_db
             ),
+            storage_uri=args.req_limit_storage,
         )
     else:
         from .no_limiter import Limiter

--- a/app/app.py
+++ b/app/app.py
@@ -177,9 +177,6 @@ def create_app(args):
 
             if flood.is_banned(ip):
                 abort(403, description="Too many request limits violations")
-            else:
-                if flood.has_violation(ip):
-                    flood.decrease(ip)
 
             if args.api_keys:
                 ak = get_req_api_key()

--- a/app/default_values.py
+++ b/app/default_values.py
@@ -57,6 +57,11 @@ _default_options_objects = [
         'value_type': 'int'
     },
     {
+        'name': 'REQ_LIMIT_STORAGE',
+        'default_value': 'memory://',
+        'value_type': 'str'
+    },
+    {
         'name': 'DAILY_REQ_LIMIT',
         'default_value': -1,
         'value_type': 'int'

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,13 @@ def get_args():
         help="Set the default maximum number of requests per minute per client (%(default)s)",
     )
     parser.add_argument(
+        "--req-limit-storage",
+        default=DEFARGS['REQ_LIMIT_STORAGE'],
+        type=str,
+        metavar="<Storage URI>",
+        help="Storage URI to use for request limit data storage. See https://flask-limiter.readthedocs.io/en/stable/configuration.html. (%(default)s)",
+    )
+    parser.add_argument(
         "--daily-req-limit",
         default=DEFARGS['DAILY_REQ_LIMIT'],
         type=int,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ argos-translate-files==1.1.0
 itsdangerous==2.1.2
 Werkzeug==2.2.2
 requests==2.28.1
+redis==4.3.4


### PR DESCRIPTION
Adds support for storing request limit information to a persistent backend (e.g. redis); this is needed when running multiple distributed instances of LT or using multiple gunicorn processes.
