### PR TITLE
Fix reference to `app` and `url`

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -16,11 +16,11 @@ RUN apt-get update && apt-get upgrade --assume-yes
 
 RUN pip3 install --upgrade pip && apt-get remove python3-pip --assume-yes
 
-COPY . .
-
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install torch==1.12.0+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+
+COPY . .
 
 RUN if [ "$with_models" = "true" ]; then  \
     # install only the dependencies first

--- a/libretranslate/init.py
+++ b/libretranslate/init.py
@@ -53,7 +53,7 @@ def check_and_install_models(force=False, load_only_lang_codes=None):
             package.install_from_path(download_path)
 
         # reload installed languages
-        app.language.languages = translate.get_installed_languages()
+        libretranslate.language.languages = translate.get_installed_languages()
         print(
             "Loaded support for %s languages (%s models total)!"
             % (len(translate.get_installed_languages()), len(available_packages))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argostranslate==1.7.0
+argostranslate==1.7.5
 Flask==2.2.2
 flask-swagger==0.2.14
 flask-swagger-ui==4.11.1


### PR DESCRIPTION
The old version of `argotranslate` was leading to the following error,

```python
Traceback (most recent call last):                                                                                                                                                            
  File "./install_models.py", line 12, in <module>                                                                                                                                            
    check_and_install_models(force=True, load_only_lang_codes=lang_codes)                                                                                                                     
  File "/app/libretranslate/init.py", line 52, in check_and_install_models                                                                                                                    
    download_path = available_package.download()                                                                                                                                              
  File "/usr/local/lib/python3.8/dist-packages/argostranslate/package.py", line 217, in download                                                                                              
    raise Exception(f"Download failed for {url}")                                                                                                                                             
NameError: name 'url' is not defined                                                                                                                                                          
```

Once the version in the requirements.txt was bumped, I was seeing an old reference to `app` that wasn't changed in a23a9fbd7528d7f37dc2b88114f119e339cadc4d. This was causing the following error,

```python
Traceback (most recent call last):
  File "./install_models.py", line 12, in <module>
    check_and_install_models(force=True, load_only_lang_codes=lang_codes)
  File "/app/libretranslate/init.py", line 56, in check_and_install_models
    app.language.languages = translate.get_installed_languages()
NameError: name 'app' is not defined
```

This pull request fixes both of these issues and also slightly restructures the nvidia Dockerfile to better use build caches. This PR is based off of the v1.3.7 tag.