### PR TITLE
added script to allow healthcheck call in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ Run this version with:
 docker-compose -f docker-compose.cuda.yml up -d --build
 ```
 
+### Running Healthchecks
+
+You can enable healthchecks by including this in your docker-compose.yml file:
+
+```
+healthcheck:
+  test: ['CMD-SHELL', './venv/bin/python healthcheck.py']
+```
+
 ## Arguments
 
 | Argument                    | Description                                                                                                 | Default              | Env. name                    |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     restart: unless-stopped
     ports:
       - "5000:5000"
+    healthcheck:
+      test: ['CMD-SHELL', './venv/bin/python healthcheck.py']
     ## Uncomment above command and define your args if necessary
     # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500
     ## Uncomment this section and the `volumes` section if you want to backup your API keys

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -1,0 +1,11 @@
+import requests
+response = requests.post(
+    url='http://0.0.0.0:5000/translate',
+    headers={'Content-Type': 'application/json'},
+    json={
+         'q': 'Hello World!',
+         'source': 'en',
+         'target': 'en'
+    }
+)
+# if server unavailable then requests with raise exception and healthcheck will fail


### PR DESCRIPTION
when launching a new container, it was always difficult to tell when the container had finished downloading all the language models. I created a simple python script to make a REST call and try to translate English to English (assuming that the user, at the very least, has the English language model installed).

calling this allows us to now check if the server is healthy / unhealthy. I've also updated `docker-compose.yml` and `README.md` with an example of how to use it.