### PR TITLE
Improve Language detection

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -518,7 +518,7 @@ def create_app(args):
                 )
             ]
         else:
-            source_langs = [{"confidence": 100.0, "language": source_lang} for _ in texts_to_translate]
+            source_langs = [{"confidence": 100.0, "language": source_lang} for _text in texts_to_translate]
 
         src_langs = [next(iter([l for l in languages if l.code == source_lang["language"]]), None) for source_lang in source_langs]
 

--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -512,12 +512,12 @@ def create_app(args):
                 auto_detect_texts = q
             else:
                 auto_detect_texts = [q]
-
-            overall_candidates = detect_languages(q)
+            allowed_languages = [_l.code for _l in languages]
+            overall_candidates = detect_languages(q, allowed_languages=allowed_languages)
 
             for text_to_check in auto_detect_texts:
                 if len(text_to_check) > 40:
-                    candidate_langs = detect_languages(text_to_check)
+                    candidate_langs = detect_languages(text_to_check, allowed_languages=allowed_languages)
                 else:
                     # Unable to accurately detect languages for short texts
                     candidate_langs = overall_candidates

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -1,71 +1,96 @@
 # Originally adapted from https://github.com/aboSamoor/polyglot/blob/master/polyglot/base.py
 
 from abc import ABC
+from collections.abc import Iterable
 
 import pycld2 as cld2
 
 class UnknownLanguage(Exception):
-  pass
+    pass
+
 
 class Language(object):
-  def __init__(self, choice):
-    name, code, confidence, bytesize = choice
-    self.code = code
-    self.name = name
-    self.confidence = float(confidence)
-    self.read_bytes = int(bytesize)
+    def __init__(self, choice: "tuple[str, str, float | int, int]") -> None:
+        name, code, confidence, bytesize = choice
+        self.code = code
+        self.name = name
+        self.confidence = float(confidence)
+        self.read_bytes = int(bytesize)
 
-  def __str__(self):
-    return ("name: {:<12}code: {:<9}confidence: {:>5.1f} "
-            "read bytes:{:>6}".format(self.name, self.code,
-                                    self.confidence, self.read_bytes))
+    def __str__(self) -> str:
+        return "name: {:<12}code: {:<9}confidence: {:>5.1f} " "read bytes:{:>6}".format(
+            self.name, self.code, self.confidence, self.read_bytes
+        )
 
-  @staticmethod
-  def from_code(code):
-    return Language(("", code, 100, 0))
+    @staticmethod
+    def from_code(code: str) -> "Language":
+        return Language(("", code, 100, 0))
 
 
 class BaseDetector(ABC):
-  """Detect the language used in a snippet of text."""
+    """Detect the language used in a snippet of text."""
 
-  def __init__(self, text: str, quiet: bool = False) -> None:
-    """ Detector of the language used in `text`.
-    Args:
-      text (string): unicode string.
-    """
-    # self.__text = text
-    self.reliable = True
-    """False if the detector used Best Effort strategy in detection."""
-    self.quiet = quiet
-    """If true, exceptions will be silenced."""
-    self.languages = self.detect(text)
-    self.language = self.languages[0]
+    def __init__(
+        self,
+        text: str,
+        quiet: bool = False,
+        allowed_languages: "Iterable[str] | None" = None,
+    ) -> None:
+        """Detector of the language used in `text`.
+        Args:
+          text (string): unicode string.
+        """
+        self.allowed_languages: "frozenset[str]" = frozenset(
+            self.supported_languages() if allowed_languages is None else allowed_languages
+        )
+        # self.__text = text
+        self.reliable: bool = True
+        """False if the detector used Best Effort strategy in detection."""
+        self.quiet: bool = quiet
+        """If true, exceptions will be silenced."""
+        self.languages: "list[Language]" = [
+            lang
+            for lang in self.detect(text)
+            if lang.code in self.allowed_languages
+        ]
+        self.language: "Language | None" = self.languages[0] if self.languages else None
+        if self.language.confidence < 0.4:
+            self.reliable = False
 
-  def __str__(self) -> str:
-    text = "Prediction is reliable: {}\n".format(self.reliable)
-    text += u"\n".join(["Language {}: {}".format(i+1, str(l))
-                        for i,l in enumerate(self.languages)])
-    return text
+    def __str__(self) -> str:
+        text = "Prediction is reliable: {}\n".format(self.reliable)
+        text += "\n".join(
+            [
+                "Language {}: {}".format(i + 1, str(l))
+                for i, l in enumerate(self.languages)
+            ]
+        )
+        return text
 
-  @staticmethod
-  def supported_languages() -> "list[str]":
-    """Returns a list of the languages that this Detector can detect."""
-    raise NotImplementedError()
+    @staticmethod
+    def supported_languages() -> "list[str]":
+        """Returns a list of the languages that this Detector can detect."""
+        raise NotImplementedError()
 
-  def detect(self, text: str) -> "list[Language]":
-    """Decide which language is used to write the text."""
-    raise NotImplementedError()
+    def detect(self, text: str) -> "list[Language]":
+        """Decide which language is used to write the text."""
+        raise NotImplementedError()
 
 
 class Detector(BaseDetector):
-    """ Detect the language used in a snippet of text."""
+    """Detect the language used in a snippet of text."""
 
     @staticmethod
     def supported_languages() -> "list[str]":
         """Returns a list of the languages that can be detected by pycld2."""
         return [name.capitalize() for name, code in cld2.LANGUAGES if not name.startswith("X_")]
+        return [
+            name.capitalize()
+            for name, code in cld2.LANGUAGES
+            if not name.startswith("X_")
+        ]
 
-    def detect(self, text) -> "list[Language]":
+    def detect(self, text: str) -> "list[Language]":
         """Decide which language is used to write the text.
         The method tries first to detect the language with high reliability. If
         that is not possible, the method switches to the best effort strategy.

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -41,7 +41,9 @@ class BaseDetector(ABC):
           text (string): unicode string.
         """
         self.allowed_languages: "frozenset[str]" = frozenset(
-            self.supported_languages() if allowed_languages is None else allowed_languages
+            self.supported_languages()
+            if allowed_languages is None
+            else [string.upper() for string in allowed_languages]
         )
         # self.__text = text
         self.reliable: bool = True
@@ -139,7 +141,7 @@ class Detector(BaseDetector):
         confidence_values: "list[tuple[lingua.Language, float]]" = detector.compute_language_confidence_values(text)
 
         return [
-            Language((language.name.title(), language.iso_code_639_1.name, confidence, 0))
+            Language((language.name.title(), language.iso_code_639_1.name, confidence, len(text)))
             for language, confidence in confidence_values
         ]
 

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -22,6 +22,14 @@ class Language(object):
             self.name, self.code, self.confidence, self.read_bytes
         )
 
+    def __repr__(self) -> str:
+        return "Language((%r, %r, %r, %r))" % (
+            self.name, self.code, self.confidence, self.read_bytes
+        )
+
+    def to_dict(self) -> "dict[str, str | int]":
+        return {"confidence": self.confidence, "language": self.code.lower()}
+
     @staticmethod
     def from_code(code: str) -> "Language":
         return Language(("", code, 100, 0))

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -133,8 +133,6 @@ class Detector(BaseDetector):
 
     def detect(self, text: str) -> "list[Language]":
         """Decide which language is used to write the text.
-        The method tries first to detect the language with high reliability. If
-        that is not possible, the method switches to the best effort strategy.
         Args:
           text (string): A snippet of text, the longer it is the more reliable we
                          can detect the language used to write the text.

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -27,8 +27,11 @@ class Language(object):
             self.name, self.code, self.confidence, self.read_bytes
         )
 
-    def to_dict(self) -> "dict[str, str | int]":
-        return {"confidence": self.confidence, "language": self.code.lower()}
+    def to_dict(self, confidence_digits: int = 2) -> "dict[str, str | int]":
+        return {
+            "confidence": round(self.confidence, confidence_digits),
+            "language": self.code.lower()
+        }
 
     @staticmethod
     def from_code(code: str) -> "Language":

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -64,8 +64,6 @@ class BaseDetector(ABC):
             if lang.code in self.allowed_languages
         ]
         self.language: "Language | None" = self.languages[0] if self.languages else None
-        if self.language.confidence < 0.4:
-            self.reliable = False
 
     def __str__(self) -> str:
         text = "Prediction is reliable: {}\n".format(self.reliable)

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -145,7 +145,7 @@ class Detector(BaseDetector):
         confidence_values: "list[tuple[lingua.Language, float]]" = detector.compute_language_confidence_values(text)
 
         return [
-            Language((language.name.title(), language.iso_code_639_1.name, confidence, len(text)))
+            Language((language.name.title(), language.iso_code_639_1.name, confidence * 100.0, len(text)))
             for language, confidence in confidence_values
         ]
 

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -44,17 +44,15 @@ class BaseDetector(ABC):
     def __init__(
         self,
         text: str,
+        allowed_languages: "list[str]",
         quiet: bool = False,
-        allowed_languages: "Iterable[str] | None" = None,
     ) -> None:
         """Detector of the language used in `text`.
         Args:
           text (string): unicode string.
         """
         self.allowed_languages: "frozenset[str]" = frozenset(
-            self.supported_languages()
-            if allowed_languages is None
-            else [string.upper() for string in allowed_languages]
+            [string.upper() for string in allowed_languages]
         )
         # self.__text = text
         self.reliable: bool = True
@@ -127,7 +125,7 @@ class LinguaDetector(BaseDetector):
     def supported_languages(cls) -> "list[str]":
         """Returns a list of the languages that can be detected by pycld2."""
         return [
-            lang.iso_code_639_1.name
+            lang.name.capitalize()
             for lang in lingua.Language.all()
         ]
 
@@ -188,10 +186,10 @@ class Detector(BaseDetector):
 
 def test_Detector():
     for lang in Detector.supported_languages():
-        assert len(lang) == 2 and lang.upper() == lang, lang
-    assert Detector("Neuland").language.code == "DE"
+        assert lang.capitalize() == lang, lang
+    assert Detector("Neuland", allowed_languages=["de", "en", "it", "fr"]).language.code == "DE"
     # https://github.com/LibreTranslate/LibreTranslate/issues/247
-    assert Detector("Tout philosophe a deux philosophies : la sienne et celle de Spinoza.").language.code == "FR"
+    assert Detector("Tout philosophe a deux philosophies : la sienne et celle de Spinoza.", allowed_languages=["de", "en", "it", "fr"]).language.code == "FR"
 
 
 if __name__ == "__main__":

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -143,10 +143,11 @@ class Detector(BaseDetector):
         ]
         detector = lingua.LanguageDetectorBuilder.from_languages(*languages).build()
         confidence_values: "list[tuple[lingua.Language, float]]" = detector.compute_language_confidence_values(text)
-
+        filter_no_confidence = max(c for _, c in confidence_values) > 0
         return [
             Language((language.name.title(), language.iso_code_639_1.name, confidence * 100.0, len(text)))
             for language, confidence in confidence_values
+            if not filter_no_confidence or confidence
         ]
 
 

--- a/libretranslate/detect.py
+++ b/libretranslate/detect.py
@@ -1,5 +1,7 @@
 # Originally adapted from https://github.com/aboSamoor/polyglot/blob/master/polyglot/base.py
 
+from abc import ABC
+
 import pycld2 as cld2
 
 class UnknownLanguage(Exception):
@@ -23,50 +25,62 @@ class Language(object):
     return Language(("", code, 100, 0))
 
 
-class Detector(object):
-  """ Detect the language used in a snippet of text."""
+class BaseDetector(ABC):
+  """Detect the language used in a snippet of text."""
 
-  def __init__(self, text, quiet=False):
+  def __init__(self, text: str, quiet: bool = False) -> None:
     """ Detector of the language used in `text`.
     Args:
       text (string): unicode string.
     """
-    self.__text = text
+    # self.__text = text
     self.reliable = True
     """False if the detector used Best Effort strategy in detection."""
     self.quiet = quiet
     """If true, exceptions will be silenced."""
-    self.detect(text)
-
-  @staticmethod
-  def supported_languages():
-    """Returns a list of the languages that can be detected by pycld2."""
-    return [name.capitalize() for name,code in cld2.LANGUAGES if not name.startswith("X_")]
-
-  def detect(self, text):
-    """Decide which language is used to write the text.
-    The method tries first to detect the language with high reliability. If
-    that is not possible, the method switches to best effort strategy.
-    Args:
-      text (string): A snippet of text, the longer it is the more reliable we
-                     can detect the language used to write the text.
-    """
-    reliable, index, top_3_choices = cld2.detect(text, bestEffort=False)
-
-    if not reliable:
-      self.reliable = False
-      reliable, index, top_3_choices = cld2.detect(text, bestEffort=True)
-      
-      if not self.quiet:
-        if not reliable:
-          raise UnknownLanguage("Try passing a longer snippet of text")
-
-    self.languages = [Language(x) for x in top_3_choices]
+    self.languages = self.detect(text)
     self.language = self.languages[0]
-    return self.language
 
-  def __str__(self):
+  def __str__(self) -> str:
     text = "Prediction is reliable: {}\n".format(self.reliable)
     text += u"\n".join(["Language {}: {}".format(i+1, str(l))
                         for i,l in enumerate(self.languages)])
     return text
+
+  @staticmethod
+  def supported_languages() -> "list[str]":
+    """Returns a list of the languages that this Detector can detect."""
+    raise NotImplementedError()
+
+  def detect(self, text: str) -> "list[Language]":
+    """Decide which language is used to write the text."""
+    raise NotImplementedError()
+
+
+class Detector(BaseDetector):
+    """ Detect the language used in a snippet of text."""
+
+    @staticmethod
+    def supported_languages() -> "list[str]":
+        """Returns a list of the languages that can be detected by pycld2."""
+        return [name.capitalize() for name, code in cld2.LANGUAGES if not name.startswith("X_")]
+
+    def detect(self, text) -> "list[Language]":
+        """Decide which language is used to write the text.
+        The method tries first to detect the language with high reliability. If
+        that is not possible, the method switches to the best effort strategy.
+        Args:
+          text (string): A snippet of text, the longer it is the more reliable we
+                         can detect the language used to write the text.
+        """
+        reliable, index, top_3_choices = cld2.detect(text, bestEffort=False)
+
+        if not reliable:
+            self.reliable = False
+            reliable, index, top_3_choices = cld2.detect(text, bestEffort=True)
+
+            if not self.quiet:
+                if not reliable:
+                    raise UnknownLanguage("Try passing a longer snippet of text")
+
+        return [Language(x) for x in top_3_choices]

--- a/libretranslate/language.py
+++ b/libretranslate/language.py
@@ -81,7 +81,7 @@ def detect_languages(text: "str | list[str]", allowed_languages: "list[str] | No
         key=lambda l: (l.confidence * l.text_length) / text_length_total, reverse=True
     )
 
-    return [{"confidence": l.confidence, "language": l.code} for l in candidate_langs]
+    return [l.to_dict() for l in candidate_langs]
 
 
 def improve_translation_formatting(source, translation, improve_punctuation=True):

--- a/libretranslate/language.py
+++ b/libretranslate/language.py
@@ -13,7 +13,7 @@ def load_languages():
 
     return __languages
 
-def detect_languages(text):
+def detect_languages(text: str, allowed_languages: "list[str] | None" = None):
     # detect batch processing
     if isinstance(text, list):
         is_batch = True
@@ -25,7 +25,7 @@ def detect_languages(text):
     candidates = []
     for t in text:
         try:
-            d = Detector(t).languages
+            d = Detector(t, allowed_languages=allowed_languages).languages
             for i in range(len(d)):
                 d[i].text_length = len(t)
             candidates.extend(d)

--- a/libretranslate/language.py
+++ b/libretranslate/language.py
@@ -13,7 +13,7 @@ def load_languages():
 
     return __languages
 
-def detect_languages(text: str, allowed_languages: "list[str] | None" = None):
+def detect_languages(text: "str | list[str]", allowed_languages: "list[str] | None" = None):
     # detect batch processing
     if isinstance(text, list):
         is_batch = True

--- a/libretranslate/language.py
+++ b/libretranslate/language.py
@@ -47,7 +47,13 @@ def detect_languages(text: "str | list[str]", allowed_languages: "list[str] | No
     # this happens if no language could be detected
     if not candidate_langs:
         # use language "en" by default but with zero confidence
-        return [{"confidence": 0.0, "language": "en"}]
+        lang = (
+            "en"
+            if allowed_languages is None or "en" in allowed_languages
+            else allowed_languages[0]
+        )
+        return [{"confidence": 0.0, "language": lang}]
+
 
     # for multiple occurrences of the same language (can happen on batch detection)
     # calculate the average confidence for each language

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-Session==0.4.0
 waitress==2.1.2
 expiringdict==1.2.2
 lingua-language-detector==1.3.1
+LTpycld2==0.42
 morfessor==2.0.6
 appdirs==1.4.4
 APScheduler==3.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Babel==2.0.0
 Flask-Session==0.4.0
 waitress==2.1.2
 expiringdict==1.2.2
-LTpycld2==0.42
+lingua-language-detector==1.3.1
 morfessor==2.0.6
 appdirs==1.4.4
 APScheduler==3.9.1


### PR DESCRIPTION
Try to fix some of the issues raised in #395 and fix #247

- Replace CDL 2 with lingua-py for "a quick boost in accuracy"
- ingore languages that are not loaded for language detection

I didn't remove the old detection class, so maybe later multiple methods can be used.

With these changes `Tout philosophe a deux philosophies : la sienne et celle de Spinoza.` can be translated when is language is auto.
Even single german words like "Pfannkuchen" get recognised.