### PR TITLE
Switches (back) to docker/Dockerfile as default for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: libretranslate
     build:
       context: .
-      dockerfile: docker/cuda.Dockerfile
+      dockerfile: docker/Dockerfile
     restart: unless-stopped
     ports:
       - "5000:5000"


### PR DESCRIPTION
I assume to use the cuda.Dockerfile as default (via docker-compose.yml) was a mistake.