### PR TITLE
Upgrade to Argos Translate 1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore db/sessions/
+db/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/libretranslate/init.py
+++ b/libretranslate/init.py
@@ -49,8 +49,7 @@ def check_and_install_models(force=False, load_only_lang_codes=None):
                 "Downloading %s (%s) ..."
                 % (available_package, available_package.package_version)
             )
-            download_path = available_package.download()
-            package.install_from_path(download_path)
+            available_package.install()
 
         # reload installed languages
         libretranslate.language.languages = translate.get_installed_languages()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argostranslate==1.7.5
+argostranslate==1.8.0
 Flask==2.2.2
 flask-swagger==0.2.14
 flask-swagger-ui==4.11.1


### PR DESCRIPTION
Uses argostranslate.package.Package.install which deletes the cached package file after it has been installed