### PR TITLE
Uninitialized variable error in check_command function - Fixed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -73,6 +73,9 @@ check_command(){
         else
             check_msg_result="\033[91m can't find $1! Check that the program is installed and that you have added the proper path to the program to your PATH environment variable before launching the program. If you change your PATH environment variable, remember to close and reopen your terminal. $2\033[39m"
         fi
+    else
+        check_msg_prefix="Checking for $1... "
+        check_msg_result="\033[92m found\033[39m"
     fi
 
     echo -e "$check_msg_prefix $check_msg_result"


### PR DESCRIPTION
This pull request addresses an issue with the check_command function in the `run-libretranslate.sh` script. When a program is found, the `check_msg_result` variable is not initialized, causing an uninitialized variable error when trying to print it at the end of the function.

To fix this issue, this pull request initializes the `check_msg_result `variable with a default message indicating that the program was found, and only changes it if the program was not found.

**The updated check_command function is as follows:**
```
# $1 = command | $2 = help_text | $3 = install_command (optional)
check_command(){
    hash "$1" 2>/dev/null || not_found=true
    if [[ $not_found ]]; then
        check_msg_prefix="Checking for $1... "

        # Can we attempt to install it?
        if [[ -n "$3" ]]; then
            echo -e "$check_msg_prefix \033[93mnot found, we'll attempt to install\033[39m"
            $3 || sudo $3

            # Recurse, but don't pass the install command
            check_command "$1" "$2"
        else
            check_msg_result="\033[91m can't find $1! Check that the program is installed and that you have added the proper path to the program to your PATH environment variable before launching the program. If you change your PATH environment variable, remember to close and reopen your terminal. $2\033[39m"
        fi
    else
        check_msg_prefix="Checking for $1... "
        check_msg_result="\033[92m found\033[39m"
    fi

    echo -e "$check_msg_prefix $check_msg_result"
    if [[ $not_found ]]; then
        return 1
    fi
}
```

With this change, the `check_msg_result` variable is always initialized, preventing the uninitialized variable error.

This pull request resolves issue #407.