### PR TITLE
Reduce docker image size

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,3 +43,15 @@ jobs:
           cache-to: type=gha,mode=max
         env:
           TAG: ${{ startsWith(github.ref, 'refs/tags/') && steps.get-variables.outputs.version || 'latest' }}
+
+      - name: Build and push Cuda Image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/cuda.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.get-variables.outputs.gh-username-lower }}/libretranslate:${{ env.TAG }}-cuda
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        env:
+          TAG: ${{ startsWith(github.ref, 'refs/tags/') && steps.get-variables.outputs.version || 'latest' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.9-slim-bullseye as builder
+FROM python:3.10.10-slim-bullseye as builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN ./venv/bin/pip install Babel==2.11.0 && ./venv/bin/python scripts/compile_lo
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 
-FROM python:3.10.9-slim-bullseye
+FROM python:3.10.10-slim-bullseye
 
 ARG with_models=false
 ARG models=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,8 @@ RUN python -mvenv venv && ./venv/bin/pip install --upgrade pip
 COPY . .
 
 # Install package from source code, compile translations
-RUN ./venv/bin/pip install Babel==2.11.0 && ./venv/bin/python scripts/compile_locales.py \
+RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_locales.py \
+  && ./venv/bin/pip install torch --extra-index-url https://download.pytorch.org/whl/cpu \
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 


### PR DESCRIPTION
Fix https://github.com/LibreTranslate/LibreTranslate/issues/359

this PR reduce the docker image size by installing torch with cpu only support https://github.com/LibreTranslate/LibreTranslate/issues/359#issuecomment-1407736532

this also publish a specific image for cuda using the [cuda.Dockerfile](https://github.com/LibreTranslate/LibreTranslate/blob/main/docker/cuda.Dockerfile)
there will be the suffix "-cuda" after the tag name for images with cuda
