### PR TITLE
Fix compatibility with flask-babel v3

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -1079,13 +1079,14 @@ def create_app(args):
         return jsonify(lazy_swag(swag))
 
     app.config["BABEL_TRANSLATION_DIRECTORIES"] = 'locales'
-    babel = Babel(app)
-    @babel.localeselector
+
     def get_locale():
         override_lang = request.headers.get('X-Override-Accept-Language')
         if override_lang and override_lang in get_available_locale_codes():
             return override_lang
         return session.get('preferred_lang', request.accept_languages.best_match(get_available_locale_codes()))
+
+    babel = Babel(app, locale_selector=get_locale)
 
     app.jinja_env.globals.update(_e=gettext_escaped, _h=gettext_html)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask==2.2.2
 flask-swagger==0.2.14
 flask-swagger-ui==4.11.1
 Flask-Limiter==2.6.3
-Flask-Babel==2.0.0
+Flask-Babel==3.1.0
 Flask-Session==0.4.0
 waitress==2.1.2
 expiringdict==1.2.2


### PR DESCRIPTION
Babel.locale_selector was [removed](https://github.com/python-babel/flask-babel/blob/69d3340cd0ff52f3e23a47518285a7e6d8f8c640/CHANGELOG) in 3.0.0.