### PR TITLE
Speed up Docker image build and make Docker image smaller

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,10 +5,9 @@ WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
   && apt-get -qqq install --no-install-recommends -y pkg-config gcc g++ \
+  && apt-get upgrade --assume-yes \
   && apt-get clean \
   && rm -rf /var/lib/apt
-
-RUN apt-get update && apt-get upgrade --assume-yes
 
 RUN python -mvenv venv && ./venv/bin/pip install --upgrade pip
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -qq \
   && apt-get clean \
   && rm -rf /var/lib/apt
 
-RUN python -mvenv venv && ./venv/bin/pip install --upgrade pip
+RUN python -mvenv venv && ./venv/bin/pip install --no-cache-dir --upgrade pip
 
 COPY . .
 

--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -9,10 +9,9 @@ WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
     && apt-get -qqq install --no-install-recommends -y libicu-dev libaspell-dev libcairo2 libcairo2-dev pkg-config gcc g++ python3.8-dev python3-pip libpython3.8-dev\
+    && apt-get upgrade --assume-yes \
     && apt-get clean \
     && rm -rf /var/lib/apt
-
-RUN apt-get update && apt-get upgrade --assume-yes
 
 RUN pip3 install --upgrade pip && apt-get remove python3-pip --assume-yes
 

--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -13,17 +13,17 @@ RUN apt-get update -qq \
     && apt-get clean \
     && rm -rf /var/lib/apt
 
-RUN pip3 install --upgrade pip && apt-get remove python3-pip --assume-yes
+RUN pip3 install --no-cache-dir --upgrade pip && apt-get remove python3-pip --assume-yes
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install torch==1.12.0+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip3 install --no-cache-dir torch==1.12.0+cu116 -f https://download.pytorch.org/whl/torch_stable.html
 
 COPY . .
 
 RUN if [ "$with_models" = "true" ]; then  \
     # install only the dependencies first
-    pip3 install -e .;  \
+    pip3 install --no-cache-dir -e .;  \
     # initialize the language models
     if [ ! -z "$models" ]; then \
     ./scripts/install_models.py --load_only_lang_codes "$models";   \


### PR DESCRIPTION
- `docker/Dockerfile` uses multi-stage build, so the image size is not affected.
- `docker/cuda.Dockerfile` image size change is huge as below, almost 2GB saved:

```
REPOSITORY          TAG                  IMAGE ID       CREATED         SIZE
after               latest               f5255fed6572   2 hours ago     8.29GB
before              latest               83dead39276f   2 hours ago     10.2GB
```