### PR TITLE
Allow UTF-8 JSON output

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -1058,6 +1058,7 @@ def create_app(args):
 
     app.config["SESSION_TYPE"] = "filesystem"
     app.config["SESSION_FILE_DIR"] = os.path.join("db", "sessions")
+    app.config["JSON_AS_ASCII"] = False
     Session(app)
 
     if args.debug:


### PR DESCRIPTION
Currently the program will escape all JSON non-ascii characters. This is the default behavior in flask.

This makes it more difficult to read the translation output in programs that don't perform JSON parsing (e.g. curl). It also takes more bytes and makes the output longer.

There doesn't seem to be any significant downside to output UTF-8 characters directly (all JSON output is already expected to be UTF-8).
