### PR TITLE
Add trans.zillyhuhn.com mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ URL |API Key Required | Links
 [translate.argosopentech.com](https://translate.argosopentech.com/)|-
 [translate.foxhaven.cyou](https://translate.foxhaven.cyou/)|-
 [translate.terraprint.co](https://translate.terraprint.co/)|-
+[trans.zillyhuhn.com](https://trans.zillyhuhn.com/)|-
 
 ## TOR/i2p Mirrors
 


### PR DESCRIPTION
I got removed when I had some downtime. But I do intend to keep this service up for a while.