### PR TITLE
fix(css): fix issues visual issues with dark theme

### DIFF
--- a/libretranslate/static/css/main.css
+++ b/libretranslate/static/css/main.css
@@ -121,11 +121,12 @@ h3.header {
   display: block;
 }
 
-.locale-panel select{
+.locale-panel select {
   display: block;
   height: 32px;
   font-size: 14px;
-  background-color: #fff;
+  color: var(--fg-color);
+  background-color: var(--pri-bg-color);
   border: none;
 }
 
@@ -429,6 +430,14 @@ code[class*="language-"], pre[class*="language-"] {
 #download-btn {
   display: flex;
   align-items: center;
+}
+
+.card-content {
+  background-color: var(--pri-bg-color);
+}
+
+.card-stacked {
+  background-color: var(--sec-bg-color)
 }
 
 @media (min-width: 280px) {

--- a/libretranslate/static/css/main.css
+++ b/libretranslate/static/css/main.css
@@ -362,6 +362,7 @@ select {
 .textarea-container textarea {
   font-size: 1.25rem;
   resize: none;
+  color: var(--fg-color);
   background: var(--sec-bg-color);
   border: 1px solid var(--border-color);
   padding: 1rem 2rem 1rem 1.5rem;


### PR DESCRIPTION
* Make the error message UI use the secondary background color defined by our theme. 
  * This fixes the theme on dark mode.
  * This changes the color in light mode to use the same color as the text areas and file upload UI.
  * UI looks more consistent with other components.

My previous PR introduced the other issues. Sorry, I should QA better. ^-^'

* Fixed a bug where the textareas had black text on dark mode. It's now white on dark mode like before.
* Fixed a bug where the language selection didn't apply the correct background color on dark theme.

## Screenshots

### Before (libretranslate.com)

![image](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/11309142-ed61-425a-9ef0-6658c671d70c)

### After

![image](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/e82acf86-3b05-44d7-8e91-1491cb5de5ec)

Reference:
* https://github.com/LibreTranslate/LibreTranslate/pull/454