### PR TITLE
fix: don't update url after character-limit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,11 +10,11 @@ insert_final_newline = true
 curly_bracket_next_line = false
 spaces_around_operators = true
 
-[*.{js,py}]
-indent_size = 4
-
-[*.{js,ts}]
+[*.js]
 quote_type = double
+
+[*.{js,js.template,py}]
+indent_size = 4
 
 [*.{markdown,md}]
 trim_trailing_whitespace = false

--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -23,7 +23,7 @@ from flask_babel import Babel
 
 from libretranslate import scheduler, flood, secret, remove_translated_files, security, storage
 from libretranslate.language import detect_languages, improve_translation_formatting
-from libretranslate.locales import (_, _lazy, get_available_locales, get_available_locale_codes, gettext_escaped, 
+from libretranslate.locales import (_, _lazy, get_available_locales, get_available_locale_codes, gettext_escaped,
         gettext_html, lazy_swag, get_alternate_locale_links)
 
 from .api_keys import Database, RemoteDatabase
@@ -149,7 +149,7 @@ def create_app(args):
     if frontend_argos_language_source is None:
         frontend_argos_language_source = languages[0]
 
-    
+
     if len(languages) >= 2:
         language_target_fallback = languages[1]
     else:
@@ -219,7 +219,7 @@ def create_app(args):
           if not os.path.isdir(default_mp_dir):
             os.mkdir(default_mp_dir)
           os.environ["PROMETHEUS_MULTIPROC_DIR"] = default_mp_dir
-        
+
       from prometheus_client import CONTENT_TYPE_LATEST, Summary, Gauge, CollectorRegistry, multiprocess, generate_latest
 
       @bp.route("/metrics")
@@ -229,7 +229,7 @@ def create_app(args):
           authorization = request.headers.get('Authorization')
           if authorization != "Bearer " + args.metrics_auth_token:
             abort(401, description=_("Unauthorized"))
-        
+
         registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
         return Response(generate_latest(registry), mimetype=CONTENT_TYPE_LATEST)
@@ -258,13 +258,13 @@ def create_app(args):
                 else:
                   need_key = False
                   key_missing = api_keys_db.lookup(ak) is None
-                  
+
                   if (args.require_api_key_origin
                       and key_missing
                       and not re.match(args.require_api_key_origin, request.headers.get("Origin", ""))
                   ):
                     need_key = True
-                  
+
                   if (args.require_api_key_secret
                     and key_missing
                     and not secret.secret_match(get_req_secret())
@@ -280,7 +280,7 @@ def create_app(args):
                         description=description,
                     )
             return f(*a, **kw)
-        
+
         if args.metrics:
           @wraps(func)
           def measure_func(*a, **kw):
@@ -302,7 +302,7 @@ def create_app(args):
           return measure_func
         else:
           return func
-    
+
     @bp.errorhandler(400)
     def invalid_api(e):
         return jsonify({"error": str(e.description)}), 400
@@ -350,17 +350,17 @@ def create_app(args):
       if args.disable_web_ui:
             abort(404)
 
-      response = Response(render_template("app.js.template", 
+      response = Response(render_template("app.js.template",
             url_prefix=args.url_prefix,
             get_api_key_link=args.get_api_key_link,
             api_secret=secret.get_current_secret() if args.require_api_key_secret else ""), content_type='application/javascript; charset=utf-8')
-      
+
       if args.require_api_key_secret:
         response.headers['Last-Modified'] = http_date(datetime.now())
         response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'
         response.headers['Pragma'] = 'no-cache'
         response.headers['Expires'] = '-1'
-      
+
       return response
 
     @bp.get("/languages")
@@ -526,6 +526,12 @@ def create_app(args):
             abort(400, description=_("Invalid request: missing %(name)s parameter", name='source'))
         if not target_lang:
             abort(400, description=_("Invalid request: missing %(name)s parameter", name='target'))
+
+        if not request.is_json:
+            # Normalize line endings to UNIX style (LF) only so we can consistently
+            # enforce character limits.
+            # https://www.rfc-editor.org/rfc/rfc2046#section-4.1.1
+            q = "\n".join(q.splitlines())
 
         batch = isinstance(q, list)
 
@@ -1067,7 +1073,7 @@ def create_app(args):
         app.register_blueprint(bp, url_prefix=args.url_prefix)
     else:
         app.register_blueprint(bp)
-    
+
     limiter.init_app(app)
 
     swag = swagger(app)

--- a/libretranslate/templates/app.js.template
+++ b/libretranslate/templates/app.js.template
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function(){
             translatedText: "",
             output: "",
             charactersLimit: -1,
-            
+
             detectedLangText: "",
 
             copyTextLabel: {{ _e("Copy text") }},
@@ -106,10 +106,6 @@ document.addEventListener('DOMContentLoaded', function(){
                     this.$refs.inputTextarea.style.height = Math.max(this.inputTextareaHeight, this.$refs.inputTextarea.scrollHeight + 32) + "px";
                     this.$refs.translatedTextarea.style.height = Math.max(this.inputTextareaHeight, this.$refs.translatedTextarea.scrollHeight + 32) + "px";
                 }
-            }
-
-            if (this.charactersLimit !== -1 && this.inputText.length >= this.charactersLimit){
-                this.inputText = this.inputText.substring(0, this.charactersLimit);
             }
 
             // Update "selected" attribute (to overcome a vue.js limitation)
@@ -212,7 +208,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 this.timeout = null;
 
                 this.detectedLangText = "";
-                
+
                 if (this.inputText === ""){
                     this.translatedText = "";
                     this.output = "";
@@ -247,7 +243,7 @@ document.addEventListener('DOMContentLoaded', function(){
                                 if (self.refreshOnce()) return;
                             }
                             {% endif %}
-                            
+
                             var res = JSON.parse(this.response);
                             // Success!
                             if (res.translatedText !== undefined){

--- a/libretranslate/templates/index.html
+++ b/libretranslate/templates/index.html
@@ -206,7 +206,7 @@
 								<label for="textarea1" class="sr-only">
 									{{ _h("Text to translate") }}
 								</label>
-								<textarea id="textarea1" v-model="inputText" @input="handleInput" ref="inputTextarea" dir="auto"></textarea>
+								<textarea id="textarea1" :maxLength="charactersLimit" v-model="inputText" @input="handleInput" ref="inputTextarea" dir="auto"></textarea>
 								<button class="btn-delete-text" title="{{ _h('Delete text') }}" aria-label="{{ _h('Delete text') }}" aria-label="Delete text" @click="deleteText">
 									<i class="material-icons">close</i>
 								</button>


### PR DESCRIPTION
## Request URI Too Large

The issue was that the URL bar was being updated with the entire paste, even though it was truncated in the textarea.

Rather than fixing that behavior, I thought we could just remove our truncation logic from `#handleInput` and rely on the browser for this, though.

The `textarea` element has a `maxLength` attribute, where we can set to the character limit. Now, the user-agent handles truncation for us in a manner the user should be used to.

Note: This **mostly** resolves the problem. I don't see this happening with normal usage, but if a user wanted to try to break things, it's possible. Special characters add multiple chars to the URL bar, so a user could manually submit a query of 1,400+ line breaks, for example, to reproduce the issue, even after this fix.

Despite that, I think that this is a good enough fix to close out the issue.

## Line Endings

While testing this behavior, I encountered a bug which is resolved by this PR as well, though the solution is a little hacky.

The spec for Form Data enforces CRLF (`\r\n`) line endings. When taking that approach to communicate with the API, the character counts mismatch between what the user submitted and what the server receives.

For example, I used the web UI to submit a 2,000-character query. However, the server actually received a 2,029-character query, and responded with a 400 because the query was "too long".

In reality, all `\n` characters were converted to `\r\n`, silently adding bytes to the request.

I've added an intermediate step if Form Data is used for communication, which normalizes the line endings to UNIX style.

### Alternative Approaches

* We could consider only using the normalized `q` to compare the length, but not actually modify `q`.
* I considered adding a buffer to `char_limit`, i.e. `char_limit + q.count("\n")`, but then users could spam and process larger requests, which is undesirable, even if it's just noise.

### Screenshots

[Screencast from 2023-07-08 03-56-30.webm](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/929557f5-c15e-4ff0-a0cc-9f88f2601b42)
> The original problem. The text is truncated to 2,000 characters (of which 71 are line breaks) in the frontend, but the backend receives 2,071 characters because of the CRLF line endings. 

[Screencast from 2023-07-08 03-57-07.webm](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/c4f60d6b-d9ca-4ecd-8649-191d32f37418)
> After applying the fix.

## Related

* Fixes https://github.com/LibreTranslate/LibreTranslate/issues/437