### PR TITLE
fix: stop double encoding query params

### DIFF
--- a/libretranslate/templates/app.js.template
+++ b/libretranslate/templates/app.js.template
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function(){
             translatedText: "",
             output: "",
             charactersLimit: -1,
-            
+
             detectedLangText: "",
 
             copyTextLabel: {{ _e("Copy text") }},
@@ -206,13 +206,13 @@ document.addEventListener('DOMContentLoaded', function(){
 
                 this.updateQueryParam('source', this.sourceLang)
                 this.updateQueryParam('target', this.targetLang)
-                this.updateQueryParam('q', encodeURI(this.inputText))
+                this.updateQueryParam('q', this.inputText)
 
                 if (this.timeout) clearTimeout(this.timeout);
                 this.timeout = null;
 
                 this.detectedLangText = "";
-                
+
                 if (this.inputText === ""){
                     this.translatedText = "";
                     this.output = "";
@@ -247,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function(){
                                 if (self.refreshOnce()) return;
                             }
                             {% endif %}
-                            
+
                             var res = JSON.parse(this.response);
                             // Success!
                             if (res.translatedText !== undefined){
@@ -464,7 +464,7 @@ function handleLangsResponse(self, response) {
         const defaultText = self.getQueryParam("q")
 
         if (defaultText) {
-            self.inputText = decodeURI(defaultText)
+            self.inputText = defaultText
             self.handleInput(new Event('none'))
         }
     } else {


### PR DESCRIPTION
While working on https://github.com/LibreTranslate/LibreTranslate/pull/458, I noticed something strange with the URLs.

A line break was encoding to `%250A`, and a space would encode to `%2520`, which doesn't seem right. Turns out special characters were being double encoded/decoded. This is mostly a waste of resources, but also increases the likelihood of a user running into https://github.com/LibreTranslate/LibreTranslate/issues/437 because it inflates the URL.

It's also why all special characters had an encoding starting with `%25`. Because they were encoded already, so `%` is the only possible special character, and then the `%` got URI encoded to `%25`.

[URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) already does URI encoding and decoding under the hood in `#set` and `#get`. There's no need for us to do it!

Here is a demonstration of the issue:

```js
const char = "<";
const encode = encodeURI(char);

const bad = encodeURI(encode); 
// Result: %253C

const params = new URLSearchParams();
params.set("q", encode); 
const bad2 = params.toString();
// Result: q=%253C
```

On libretranslate.com, if you insert `<` in the translation textarea, it currently becomes `%253C` which is not the expected URI encoded string. It should be `%3C`!

```js
const query = new URLSearchParams(); 
query.set("q", "<");
const good = query.toString();
// Result: q=%3C

const good2 = query.get("q");
// Result: <
```