### PR TITLE
fix: request and push notification on file translations

### DIFF
--- a/libretranslate/static/css/main.css
+++ b/libretranslate/static/css/main.css
@@ -436,7 +436,7 @@ code[class*="language-"], pre[class*="language-"] {
   background-color: var(--pri-bg-color);
 }
 
-.card-stacked {
+.card-stacked, .card-stacked .card-content {
   background-color: var(--sec-bg-color)
 }
 

--- a/libretranslate/templates/app.js.template
+++ b/libretranslate/templates/app.js.template
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function(){
             translatedText: "",
             output: "",
             charactersLimit: -1,
-            
+
             detectedLangText: "",
 
             copyTextLabel: {{ _e("Copy text") }},
@@ -212,7 +212,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 this.timeout = null;
 
                 this.detectedLangText = "";
-                
+
                 if (this.inputText === ""){
                     this.translatedText = "";
                     this.output = "";
@@ -247,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function(){
                                 if (self.refreshOnce()) return;
                             }
                             {% endif %}
-                            
+
                             var res = JSON.parse(this.response);
                             // Success!
                             if (res.translatedText !== undefined){
@@ -405,6 +405,7 @@ document.addEventListener('DOMContentLoaded', function(){
                                 link.target = "_blank";
                                 link.href = self.translatedFileUrl;
                                 link.click();
+                                handleNotification("Translation Complete", "Finished translating " + self.inputFile.name + ".");
                             }else{
                                 throw new Error(res.error || {{ _e("Unknown error") }});
                             }
@@ -413,22 +414,27 @@ document.addEventListener('DOMContentLoaded', function(){
                             self.error = e.message;
                             self.loadingFileTranslation = false;
                             self.inputFile = false;
+                            handleNotification("Translation Failed", e.message);
                         }
                     }else{
                         let res = JSON.parse(this.response);
                         self.error = res.error || {{ _e("Unknown error") }};
                         self.loadingFileTranslation = false;
                         self.inputFile = false;
+                        handleNotification("Translation Failed", self.error);
                     }
                 }
 
                 translateFileRequest.onerror = function() {
-                    self.error = {{ _e("Cannot load %(url)s", url="/translate_file") }};
+                    const message = {{ _e("Cannot load %(url)s", url="/translate_file") }};
+                    self.error = message;
                     self.loadingFileTranslation = false;
                     self.inputFile = false;
+                    handleNotification("Translation Failed", message);
                 };
 
                 translateFileRequest.send(data);
+                Notification.requestPermission();
             }
         }
     });
@@ -472,6 +478,17 @@ function handleLangsResponse(self, response) {
     }
 
     self.loading = false;
+}
+
+/**
+ * @param {string} title
+ * @param {string} body
+ */
+function handleNotification(title, body) {
+  new Notification(title, {
+      body,
+      tag: 'libretranslate'
+  });
 }
 
 /**

--- a/libretranslate/templates/app.js.template
+++ b/libretranslate/templates/app.js.template
@@ -402,8 +402,8 @@ document.addEventListener('DOMContentLoaded', function(){
                                 self.translatedFileUrl = res.translatedFileUrl;
 
                                 let link = document.createElement("a");
-                                link.target = "_blank";
                                 link.href = self.translatedFileUrl;
+                                link.download = "";
                                 link.click();
                                 handleNotification("Translation Complete", "Finished translating " + self.inputFile.name + ".");
                             }else{


### PR DESCRIPTION
Upon initiating a file translation, we request permission to notify the user.
Once the user responds to the request, they shouldn't get asked again unless they remove the permission explicitly or reset their browser.

Once the translation completes, we'll notify the user using the browser notification API.

## Notes

I considered only requesting/sending notifications if the request took longer than X milliseconds to complete. The motivation was that we don't spam users if they have tiny files anyway, where they couldn't have feasibly left the UI/device by the time it finished.

I opted against this because:

* It can be annoying if sometimes it notifies and other times it doesn't, and it's unclear to the user why.
* If we don't the only indication that is has finished would be visual, which isn't ideal. Until we have something more accessible in the UI, it's a solid fallback anyway.

## Screenshots

![image](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/dcf7a259-8842-458c-be0d-0b34a8f31fb8)
> GNOME notification when file translation completes succesfully.

## Related

* Fixes https://github.com/LibreTranslate/LibreTranslate/issues/305

## Chores

I did two chores in this PR as well.

### Pop-up Blocking

Removes `_target` and adds `download` to the download link attributes. This will stop browsers from treating it like a pop-up.

![](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/e209229d-6e0c-42a7-b837-b9d982fa8345)
> On libretranslate.com, the automatic download on completion didn't start because Firefox determined this was a pop-up. Users either have to click the Download button or explicitly or give the site permission to open pop-ups.

Now it'll just automagically download and we're all good. :+1: 

### Dark Theme

Another issue with styling, I honestly have no idea how I didn't catch this one. I literally included screenshots in my previous PR. :thinking: 


