### PR TITLE
fix: make code blocks match height

### DIFF
--- a/libretranslate/static/css/main.css
+++ b/libretranslate/static/css/main.css
@@ -381,6 +381,16 @@ select {
   border: 0;
 }
 
+.code-row-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.code-box {
+  display: flex;
+  flex-direction: column;
+}
+
 .code {
   font-size: 90%;
   padding: 1rem 1.5rem;
@@ -391,6 +401,7 @@ select {
   min-height: 280px;
   width: 100%;
   overflow: auto;
+  flex-grow: 1;
 }
 
 code[class*="language-"], pre[class*="language-"] {

--- a/libretranslate/templates/index.html
+++ b/libretranslate/templates/index.html
@@ -287,13 +287,13 @@
 				<div class="row center">
 					<div class="col s12 m12">
 
-					<div class="row center">
-						<div class="col s12 m12 l6 left-align">
+					<div class="row center code-row-wrapper">
+						<div class="col s12 m12 l6 left-align code-box">
 							<p class="mb-0">{{ _h("Request") }}</p>
 							<pre class="code mt-0"><code class="language-javascript" v-html="$options.filters.highlight(requestCode)">
 							</code></pre>
 						</div>
-						<div class="col s12 m12 l6 left-align">
+						<div class="col s12 m12 l6 left-align code-box">
 							<p class="mb-0">{{ _h("Response") }}</p>
 							<pre class="code mt-0"><code class="language-javascript" v-html="$options.filters.highlight(output)">
 							</code></pre>


### PR DESCRIPTION
When the code blocks are side-by-side, ensure they're equal height, regardless of the contents of them.

Note: This has no relation to the textareas above, I just included them in the screenshots for more context of the page.

## Screenshots

### Before

![image](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/2a11292e-6248-4a85-be63-828d572436aa)

### After

![image](https://github.com/LibreTranslate/LibreTranslate/assets/22801583/c13fe196-b3d1-4380-a3c4-eea8ccba5a0a)

## Related

* Partially resolves https://github.com/LibreTranslate/LibreTranslate/issues/310