### PR TITLE
Always show favicon

### DIFF
--- a/libretranslate/templates/index.html
+++ b/libretranslate/templates/index.html
@@ -7,10 +7,11 @@
 	{% endfor %}
 	{% if web_version %}
 	<title>LibreTranslate - {{ _h("Free and Open Source Machine Translation API") }}</title>
-	<link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
 	<meta name="description" content="{{ _h('Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup. Run your own API server in just a few minutes.') }}">
 	<meta name="keywords" content="{{ _h('translation') }},{{ _h('api') }}">
 	{% endif %}
+
+	<link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
 
 	<link rel="preload" href="{{ url_for('static', filename='icon.svg') }}" as="image" />
 	<link rel="preload" href="{{ url_for('static', filename='js/vue@2.js') }}" as="script">


### PR DESCRIPTION
Currently the LibreTranslate web app only shows
the favicon icon when the `LT_WEB=1` environment
variable is set. LT_WEB is used to disable
metadata by default to prevent search engines
from indexing private LibreTranslate instances.
This commit makes the favicon available even when
the metadata is disabled.

- https://github.com/LibreTranslate/LibreTranslate/issues/471