### PR TITLE
Upgrade argos-translate-files to 1.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "appdirs ==1.4.4",
     "APScheduler ==3.9.1",
     "translatehtml ==1.5.2",
-    "argos-translate-files ==1.1.1",
+    "argos-translate-files ==1.1.4",
     "itsdangerous ==2.1.2",
     "Werkzeug ==2.2.2",
     "requests ==2.28.1",


### PR DESCRIPTION
This version of Argos Translate Files improves
translation of EPUB ebook documents.

https://github.com/LibreTranslate/argos-translate-files/commit/81daf7649219acc2c2e01fd26ea4b7c3426a8701