### PR TITLE
Fix text color in dark mode

### DIFF
--- a/libretranslate/static/css/main.css
+++ b/libretranslate/static/css/main.css
@@ -180,6 +180,10 @@ select {
   color: var(--fg-color);
 }
 
+select option {
+  color: var(--pri-bg-color);
+}
+
 .language-select {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Currently when the browser has a dark theme enabled the language selection dropdown has white text on a white background that is un-readable.

This commit changes the dropdown select to have black text on a white background.

https://github.com/LibreTranslate/LibreTranslate/issues/491