### PR TITLE
Remove YAML validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,6 @@ repos:
       name: " 🐘 Check for added large files"
     - id: check-toml
       name: " ✔️  Check TOML"
-    - id: check-yaml
-      name: " ✔️  Check YAML"
-      args:
-      - --unsafe
     - id: check-json
       name: " ✔️  Check JSON"
     - id: trailing-whitespace


### PR DESCRIPTION
The YAML validation step is currently failing
on the chart directory. This commit removes the
YAML check.

Error:
$ hatch run test
 ✔️  Check YAML..........................................................Failed
- hook id: check-yaml
- exit code: 1

while parsing a flow node
did not find expected node content
  in "chart/templates/pvc.yaml", line 1, column 3 while parsing a flow node
did not find expected node content
  in "chart/templates/statefulset.yaml", line 6, column