### PR TITLE
Add option to update models rather than reinstall

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -125,7 +125,7 @@ def get_routes_limits(default_req_limit, daily_req_limit, api_keys_db):
 def create_app(args):
     from libretranslate.init import boot
 
-    boot(args.load_only, args.update_models)
+    boot(args.load_only, args.update_models, args.install_models)
 
     from libretranslate.language import load_languages
 
@@ -1042,7 +1042,6 @@ def create_app(args):
         s = request.values.get("s")
         source_lang = request.values.get("source")
         target_lang = request.values.get("target")
-
         if not q:
             abort(400, description=_("Invalid request: missing %(name)s parameter", name='q'))
         if not s:

--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -125,7 +125,7 @@ def get_routes_limits(default_req_limit, daily_req_limit, api_keys_db):
 def create_app(args):
     from libretranslate.init import boot
 
-    boot(args.load_only, args.update_models, args.install_models)
+    boot(args.load_only, args.update_models, args.force_update_models)
 
     from libretranslate.language import load_languages
 

--- a/libretranslate/default_values.py
+++ b/libretranslate/default_values.py
@@ -172,6 +172,11 @@ _default_options_objects = [
         'value_type': 'bool'
     },
     {
+        'name': 'INSTALL_MODELS',
+        'default_value': False,
+        'value_type': 'bool'
+    },
+    {
         'name': 'METRICS',
         'default_value': False,
         'value_type': 'bool'

--- a/libretranslate/default_values.py
+++ b/libretranslate/default_values.py
@@ -172,7 +172,7 @@ _default_options_objects = [
         'value_type': 'bool'
     },
     {
-        'name': 'INSTALL_MODELS',
+        'name': 'FORCE_UPDATE_MODELS',
         'default_value': False,
         'value_type': 'bool'
     },

--- a/libretranslate/init.py
+++ b/libretranslate/init.py
@@ -1,5 +1,6 @@
 
 from argostranslate import package, translate
+from packaging import version
 
 import libretranslate.language
 
@@ -55,7 +56,7 @@ def check_and_install_models(force=False, load_only_lang_codes=None,update=False
                             and pack.to_code == available_package.to_code
                         ):
                         update = True
-                        if pack.package_version < available_package.package_version:
+                        if version.parse(pack.package_version) < version.parse(available_package.package_version):
                             print(
                                 f"Updating {available_package} ({pack.package_version}->{available_package.package_version}) ..."
                             )

--- a/libretranslate/main.py
+++ b/libretranslate/main.py
@@ -161,7 +161,7 @@ def get_args():
         "--update-models", default=DEFARGS['UPDATE_MODELS'], action="store_true", help="Update language models at startup"
     )
     parser.add_argument(
-        "--install-models", default=DEFARGS['INSTALL_MODELS'], action="store_true", help="Install language models at startup"
+        "--force-update-models", default=DEFARGS['FORCE_UPDATE_MODELS'], action="store_true", help="Install/Reinstall language models at startup"
     )
     parser.add_argument(
         "--metrics",

--- a/libretranslate/main.py
+++ b/libretranslate/main.py
@@ -161,6 +161,9 @@ def get_args():
         "--update-models", default=DEFARGS['UPDATE_MODELS'], action="store_true", help="Update language models at startup"
     )
     parser.add_argument(
+        "--install-models", default=DEFARGS['INSTALL_MODELS'], action="store_true", help="Install language models at startup"
+    )
+    parser.add_argument(
         "--metrics",
         default=DEFARGS['METRICS'],
         action="store_true",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "redis ==4.3.4",
     "prometheus-client ==0.15.0",
     "polib ==1.1.1",
+    "packaging ==23.1"
 ]
 
 [project.scripts]

--- a/scripts/install_models.py
+++ b/scripts/install_models.py
@@ -10,8 +10,12 @@ from libretranslate.init import check_and_install_models
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--load_only_lang_codes", type=str, default="")
+    parser.add_argument("--update", action='store_true')
     args = parser.parse_args()
     lang_codes = args.load_only_lang_codes.split(",")
     if len(lang_codes) == 0 or lang_codes[0] == '':
         lang_codes = None
-    check_and_install_models(force=True, load_only_lang_codes=lang_codes)
+    if args.update:
+        check_and_install_models(update=True, load_only_lang_codes=lang_codes)
+    else:
+        check_and_install_models(force=True, load_only_lang_codes=lang_codes)


### PR DESCRIPTION
This will change the behavior of `--update-models` to only update models if there's a newer version available (or install any missing models)
Adds the option `--install-models` to force (re) installation of all models
Also adds `--update` to `scripts/install_models.py` to only update models if there's a newer version available (or install any missing models)

Will solve #502 