### PR TITLE
Don't require API key for suggestions

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -979,7 +979,6 @@ def create_app(args):
         )
 
     @bp.post("/suggest")
-    @access_check
     def suggest():
         """
         Submit a suggestion to improve a translation


### PR DESCRIPTION
Remove the access check when a user submits
a suggestion. This allows submitting translation
suggestions without an API key or secret.

https://github.com/LibreTranslate/LibreTranslate/issues/490