### PR TITLE
Remove lt.psf.lt

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ URL |API Key Required | Links
 [translate.foxhaven.cyou](https://translate.foxhaven.cyou/)|-
 [translate.terraprint.co](https://translate.terraprint.co/)|-
 [trans.zillyhuhn.com](https://trans.zillyhuhn.com/)|-
-[lt.psf.lt](https://lt.psf.lt/)|-
 
 ## TOR/i2p Mirrors
 


### PR DESCRIPTION
Around the time the instance was added, we had a hardware failure which limited the amount of resources we had. Hence we unfortunately have decided to discontinue Libre Translate :(