### PR TITLE
Use langdetect

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -554,22 +554,8 @@ def create_app(args):
                 )
 
         if source_lang == "auto":
-            source_langs = []
-            auto_detect_texts = q if batch else [q]
-
-            overall_candidates = detect_languages(q)
-
-            for text_to_check in auto_detect_texts:
-                if len(text_to_check) > 40:
-                    candidate_langs = detect_languages(text_to_check)
-                else:
-                    # Unable to accurately detect languages for short texts
-                    candidate_langs = overall_candidates
-                source_langs.append(candidate_langs[0])
-
-                if args.debug:
-                    print(text_to_check, candidate_langs)
-                    print("Auto detected: %s" % candidate_langs[0]["language"])
+            candidate_langs = detect_languages(q if batch else [q])
+            source_langs = [candidate_langs[0]]
         else:
             if batch:
                 source_langs = [ {"confidence": 100.0, "language": source_lang} for text in q]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "Flask-Session ==0.4.0",
     "waitress ==2.1.2",
     "expiringdict ==1.2.2",
-    "linguars==0.4.0",
+    "langdetect==1.0.9",
     "lexilang==1.0.1",
     "morfessor ==2.0.6",
     "appdirs ==1.4.4",


### PR DESCRIPTION
Use langdetect in place of linguars. langdetect doesn't work as well as linguars, but is quite faster and should perform better than cld2.

It might be possible in the future to use lingua, as official bindings become available.

I've left the lingua branch here: https://github.com/LibreTranslate/LibreTranslate/tree/lingua

I've also refactored some logic; we were calling `detect` twice to account for sentences with shorter length. This should no longer be needed.


