### PR TITLE
Remove translate.argosopentech.com mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ This is a list of public LibreTranslate instances, some require an API key. If y
 URL |API Key Required | Links
 --- | --- | ---
 [libretranslate.com](https://libretranslate.com)|:heavy_check_mark:|[ [Get API Key](https://portal.libretranslate.com) ] [ [Service Status](https://status.libretranslate.com/) ]
-[translate.argosopentech.com](https://translate.argosopentech.com/)|-
 [translate.foxhaven.cyou](https://translate.foxhaven.cyou/)|-
 [translate.terraprint.co](https://translate.terraprint.co/)|-
 [trans.zillyhuhn.com](https://trans.zillyhuhn.com/)|-


### PR DESCRIPTION
This instance is already overburdened and I want to stop directing new users to it.

I'm having a hard time keeping the translate.argosopentech.com LibreTranslate mirror up on the current server. The CPU usage is consistently at 100% because so many people are making requests. I limited requests to 3/minute per IP address but am still having issues.