### PR TITLE
Add hourly req limit option

### DIFF
--- a/libretranslate/default_values.py
+++ b/libretranslate/default_values.py
@@ -62,6 +62,11 @@ _default_options_objects = [
         'value_type': 'str'
     },
     {
+        'name': 'HOURLY_REQ_LIMIT',
+        'default_value': -1,
+        'value_type': 'int'
+    },
+    {
         'name': 'DAILY_REQ_LIMIT',
         'default_value': -1,
         'value_type': 'int'

--- a/libretranslate/main.py
+++ b/libretranslate/main.py
@@ -36,6 +36,13 @@ def get_args():
         help="Storage URI to use for request limit data storage. See https://flask-limiter.readthedocs.io/en/stable/configuration.html. (%(default)s)",
     )
     parser.add_argument(
+        "--hourly-req-limit",
+        default=DEFARGS['HOURLY_REQ_LIMIT'],
+        type=int,
+        metavar="<number>",
+        help="Set the default maximum number of requests per hour per client, in addition to req-limit. (%(default)s)",
+    )
+    parser.add_argument(
         "--daily-req-limit",
         default=DEFARGS['DAILY_REQ_LIMIT'],
         type=int,


### PR DESCRIPTION
Adds `--hourly-req-limit` in addition to `--req-limit` and `--daily-req-limit` for even finer granularity on limit configurations.

