### PR TITLE
Add hourly decay limit

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -44,6 +44,22 @@ jobs:
         env:
           TAG: ${{ startsWith(github.ref, 'refs/tags/') && steps.get-variables.outputs.version || 'latest' }}
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Build and push Cuda Image
         uses: docker/build-push-action@v5
         with:

--- a/libretranslate/default_values.py
+++ b/libretranslate/default_values.py
@@ -67,6 +67,11 @@ _default_options_objects = [
         'value_type': 'int'
     },
     {
+        'name': 'HOURLY_REQ_LIMIT_DECAY',
+        'default_value': 0,
+        'value_type': 'int'
+    },
+    {
         'name': 'DAILY_REQ_LIMIT',
         'default_value': -1,
         'value_type': 'int'

--- a/libretranslate/main.py
+++ b/libretranslate/main.py
@@ -43,6 +43,13 @@ def get_args():
         help="Set the default maximum number of requests per hour per client, in addition to req-limit. (%(default)s)",
     )
     parser.add_argument(
+        "--hourly-req-limit-decay",
+        default=DEFARGS['HOURLY_REQ_LIMIT_DECAY'],
+        type=int,
+        metavar="<number>",
+        help="When used in combination with hourly-req-limit, adds additional hourly restrictions that logaritmically decrease for each additional hour. (%(default)s)",
+    )
+    parser.add_argument(
         "--daily-req-limit",
         default=DEFARGS['DAILY_REQ_LIMIT'],
         type=int,


### PR DESCRIPTION
Adds a `--hourly-req-limit-decay` option which adds exponentially lower hourly limits when used in conjunction with `--hourly-req-limit`. 

Also attempts to fix the CI by freeing up space on the GH runners.