### PR TITLE
ltmanage in bin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,24 @@ services:
     restart: unless-stopped
     ports:
       - "5000:5000"
+    ## Uncomment this for logging in docker compose logs
+    # tty: true
     healthcheck:
-      test: ['CMD-SHELL', './venv/bin/python scripts/healthcheck.py']
+      test: ['CMD-SHELL', './venv/bin/python scripts/healthcheck.py']     
     ## Uncomment above command and define your args if necessary
     # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500
-    ## Uncomment this section and the `volumes` section if you want to backup your API keys
+    ## Uncomment this section and the libretranslate_api_keys volume if you want to backup your API keys
     # environment:
+    #   - LT_API_KEYS=true
     #   - LT_API_KEYS_DB_PATH=/app/db/api_keys.db # Same result as `db/api_keys.db` or `./db/api_keys.db`
+    ## Uncomment these vars and libretranslate_models volume to optimize loading time.
+    #   - LT_UPDATE_MODELS=true
+    #   - LT_LOAD_ONLY=en,fr
     # volumes:
-    #   - libretranslate_api_keys:/app/db/api_keys.db
+    #   - libretranslate_api_keys:/app/db
+    # Keep the models in a docker volume, to avoid re-downloading on startup
+    #   - libretranslate_models:/home/libretranslate/.local:rw
 
 # volumes:
 #   libretranslate_api_keys:
+#   libretranslate_models:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,8 @@ USER libretranslate
 COPY --from=builder --chown=1032:1032 /app /app
 WORKDIR /app
 
+COPY --from=builder --chown=1032:1032 /app/venv/bin/ltmanage /bin/
+
 RUN if [ "$with_models" = "true" ]; then  \
   # initialize the language models
   if [ ! -z "$models" ]; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ USER libretranslate
 COPY --from=builder --chown=1032:1032 /app /app
 WORKDIR /app
 
-COPY --from=builder --chown=1032:1032 /app/venv/bin/ltmanage /bin/
+COPY --from=builder --chown=1032:1032 /app/venv/bin/ltmanage /usr/bin/
 
 RUN if [ "$with_models" = "true" ]; then  \
   # initialize the language models


### PR DESCRIPTION
This allows using the API key instructions from the read-me "as-is" in the docker container.
See also https://community.libretranslate.com/t/where-do-i-find-ltmanage-command/406

I also corrected the path to the keys db in the docker compose file comments, otherwise it did not work in my setup:
`libretranslate_api_keys:/app/db/api_keys.db` -> `libretranslate_api_keys:/app/db`

Tests: For some reason, on my localhost, the api-keys option did not block requests done through the UI (event before my changes). So, I tested by rate-limiting users to 0/minute and creating an API key that allows 120/minute. 

A similar setup could be done for cuda version.