### PR TITLE
Specify the supported color schemes

### DIFF
--- a/libretranslate/templates/index.html
+++ b/libretranslate/templates/index.html
@@ -49,6 +49,8 @@
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/material-icons.css') }}" />
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/prism.min.css') }}" />
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}?v={{ version }}" />
+
+	<meta name="color-scheme" content="light dark">
 </head>
 
 <body>


### PR DESCRIPTION
Specify the color schemes that are supported by the site's css style. This allows browsers/addons like Dark Reader to pick up that the page supports a dark mode and doesn't need to automatically adjust it.