### PR TITLE
Fix localization on docker/pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ Documentation = "https://github.com/LibreTranslate/LibreTranslate"
 Tracker = "https://github.com/LibreTranslate/LibreTranslate/issues"
 History = "https://github.com/LibreTranslate/LibreTranslate/releases"
 
+[tool.hatch.build]
+artifacts = ["*.mo"]
 
 # ENVIRONMENTS AND SCRIPTS
 [tool.hatch.envs.default]


### PR DESCRIPTION
This PR should fix #576

The root cause is that .mo files were not being copied by pip install, since they are listed as a .gitignore pattern.

