### PR TITLE
Update Argos Translate to v1.9.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "argostranslate ==1.9.1",
+    "argostranslate ==1.9.4",
     "Flask ==2.2.5",
     "flask-swagger ==0.2.14",
     "flask-swagger-ui ==4.11.1",


### PR DESCRIPTION
This fixes an issue in SentencePiece where the packaging is broken for newer versions of Python.

https://github.com/argosopentech/argos-translate/issues/405