### PR TITLE
Update Argos Translate to v1.9.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "argostranslate ==1.9.4",
+    "argostranslate ==1.9.6",
     "Flask ==2.2.5",
     "flask-swagger ==0.2.14",
     "flask-swagger-ui ==4.11.1",


### PR DESCRIPTION
- Upgrade CTranslate2 to v4 for CUDA 12 support (https://github.com/argosopentech/argos-translate/pull/404)
- Fix deprecation error for CTranslate2 TranslationResult (https://github.com/argosopentech/argos-translate/pull/404)
