### PR TITLE
Update Dockerfile to add NumPy <2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ COPY . .
 # Install package from source code, compile translations
 RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_locales.py \
   && ./venv/bin/pip install torch==2.0.1 --extra-index-url https://download.pytorch.org/whl/cpu \
+  && ./venv/bin/pip install "numpy<2" \
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -16,6 +16,7 @@ COPY . .
 # Install package from source code, compile translations
 RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_locales.py \
   && ./venv/bin/pip install torch==2.0.1 --extra-index-url https://download.pytorch.org/whl/cpu \
+  && ./venv/bin/pip install "numpy<2" \
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 

--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -34,6 +34,7 @@ RUN if [ "$with_models" = "true" ]; then  \
 
 # Install package from source code
 RUN pip3 install Babel==2.12.1 && python3 scripts/compile_locales.py \
+    && ./venv/bin/pip install "numpy<2" \
     && pip3 install . \
     && pip3 cache purge
 


### PR DESCRIPTION
**Description:**

This PR updates the projects Dockerfiles to ensure that the NumPy package installed is compatible with version 2. By adding `&& ./venv/bin/pip install "numpy<2"` to the package installations, we guarantee that the Docker image is built with a compatible version of NumPy.

**Changes:**

* Modified the Dockerfile to install NumPy with a version less than 2 using `./venv/bin/pip install "numpy<2"`

**Why:**

This change is necessary to ensure that our Docker image is compatible with projects that rely on NumPy version 1.x. By specifying a version less than 2, we can avoid potential compatibility issues and ensure a smooth build process.

**Testing:**

The updated Dockerfile has been tested and verified to build successfully with a compatible version of NumPy.

**Checklist:**

* [x] Dockerfile updated to install NumPy with version <2
* [x] Tested and verified the updated Dockerfile builds successfully

Solves https://github.com/LibreTranslate/LibreTranslate/issues/638