### PR TITLE
Fix English language name for uk locale

### DIFF
--- a/libretranslate/locales/messages.pot
+++ b/libretranslate/locales/messages.pot
@@ -295,10 +295,6 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: libretranslate/locales/.langs.py:45
-msgid "Ukranian"
-msgstr ""
-
 #: libretranslate/locales/.langs.py:46
 msgid "Urdu"
 msgstr ""

--- a/libretranslate/locales/uk/meta.json
+++ b/libretranslate/locales/uk/meta.json
@@ -1,4 +1,4 @@
 {
-    "name": "Ukranian",
+    "name": "Ukrainian",
     "reviewed": true
 }


### PR DESCRIPTION
The language appeared in the `.pot` twice, hence the delete instead of an edit.