### PR TITLE
Take down offline instance trans.zillyhuhn.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,6 @@ This is a list of public LibreTranslate instances, some require an API key. If y
 | ----------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------- |
 | [libretranslate.com](https://libretranslate.com)            | :heavy_check_mark: | [ [Get API Key](https://portal.libretranslate.com) ] [ [Service Status](https://status.libretranslate.com/) ] |
 | [translate.terraprint.co](https://translate.terraprint.co/) | -                  |
-| [trans.zillyhuhn.com](https://trans.zillyhuhn.com/)         | -                  |
 | [translate.lotigara.ru](https://translate.lotigara.ru)      | -                  |
 
 ## TOR/i2p Mirrors


### PR DESCRIPTION
I have been providing trans.zillyhuhn.com for free for quite some time. But I sadly have to take it down now because the memory leaks are getting too annoying (See #545).

Feel free to ping me once it is fixed and I will likely spin up an instance again.