### PR TITLE
Change the default for ARGOS_DEVICE_TYPE to auto

### DIFF
--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:12.4.1-devel-ubuntu20.04
 
-ENV ARGOS_DEVICE_TYPE cuda
+ENV ARGOS_DEVICE_TYPE auto
 ARG with_models=false
 ARG models=""
 


### PR DESCRIPTION
this changes the `ARGOS_DEVICE_TYPE` environment variable to `auto` as discussed in #713 

Closes #713
