### PR TITLE
Update Dockerfile Python base image to mitigate some security issues

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.9-slim-bullseye AS builder
+FROM python:3.11.11-slim-bullseye AS builder
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_lo
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 
-FROM python:3.11.9-slim-bullseye
+FROM python:3.11.11-slim-bullseye
 
 ARG with_models=false
 ARG models=""

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/python:3.11.9-slim-bullseye as builder
+FROM arm64v8/python:3.11.11-slim-bullseye as builder
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_lo
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 
-FROM arm64v8/python:3.11.9-slim-bullseye
+FROM arm64v8/python:3.11.11-slim-bullseye
 
 ARG with_models=false
 ARG models=""


### PR DESCRIPTION
It's just a minor version bump to mitigate some base image security issues. We could also upgrade to Python v3.12 or v3.13 later if needed.