### PR TITLE
Mark Chinese as reviewed in the README's UI Languages list

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ To help improve or review the UI translations:
 | Arabic                |                    | [Edit](https://hosted.weblate.org/translate/libretranslate/app/ar/)      |
 | Azerbaijani           |                    | [Edit](https://hosted.weblate.org/translate/libretranslate/app/az/)      |
 | Basque                | :heavy_check_mark: | [Edit](https://hosted.weblate.org/translate/libretranslate/app/eu/)      |
-| Chinese               |                    | [Edit](https://hosted.weblate.org/translate/libretranslate/app/zh/)      |
+| Chinese               | :heavy_check_mark: | [Edit](https://hosted.weblate.org/translate/libretranslate/app/zh/)      |
 | Chinese (Traditional) |                    | [Edit](https://hosted.weblate.org/translate/libretranslate/app/zh_Hant/) |
 | Czech                 | :heavy_check_mark: | [Edit](https://hosted.weblate.org/translate/libretranslate/app/cs/)      |
 | Danish                |                    | [Edit](https://hosted.weblate.org/translate/libretranslate/app/da/)      |


### PR DESCRIPTION
Over the past few days, I’ve refined the Chinese translations. The updates are now complete and include:

  - Fixed incorrect translations
  - Localized phrases to sound more natural
  - Ensured consistency

I believe the Chinese translations can now be marked as reviewed.