### PR TITLE
Support LT_PORT in healtcheck script

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,7 +1,9 @@
 import requests
+import os
 
+port = os.environ.get('LT_PORT', '5000')
 response = requests.post(
-    url='http://localhost:5000/translate',
+    url=f'http://localhost:{port}/translate',
     headers={'Content-Type': 'application/json'},
     json={
          'q': 'Hello World!',


### PR DESCRIPTION
It is possible to specify a custom listening port using the environmental variable `LT_PORT`. However, when doing this, the health check script will always fail due to a hard-coded port 5000 here. This PR makes the health check script aware of `LT_PORT` (if set). 