### PR TITLE
Add --hide-api to hide the API request/response fields from the web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Arguments passed to the process or set via environment variables are split into 
 | --disable-web-ui              | Disable web ui                                                                                              | `Web Ui enabled`                   | LT_DISABLE_WEB_UI              |
 | --update-models               | Update language models at startup                                                                           | `Only on if no models found`       | LT_UPDATE_MODELS               |
 | --metrics                     | Enable the /metrics endpoint for exporting [Prometheus](https://prometheus.io/) usage metrics               | `Disabled`                         | LT_METRICS                     |
+| --hide-api                    | Hide the API request/response section in the web UI                                                         | `Disabled`                         | LT_HIDE_API                    |
 
 ### Configuration Parameters
 

--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -446,6 +446,7 @@ def create_app(args):
             current_locale=get_locale(),
             alternate_locales=get_alternate_locale_links(),
             under_attack=args.under_attack,
+            hide_api=args.hide_api,
         ))
 
         if args.require_api_key_secret:

--- a/libretranslate/default_values.py
+++ b/libretranslate/default_values.py
@@ -162,6 +162,11 @@ _default_options_objects = [
         'value_type': 'bool'
     },
     {
+        'name': 'HIDE_API',
+        'default_value': False,
+        'value_type': 'bool'
+    },
+    {
         'name': 'SHARED_STORAGE',
         'default_value': 'memory://',
         'value_type': 'str'

--- a/libretranslate/main.py
+++ b/libretranslate/main.py
@@ -154,6 +154,12 @@ def get_args():
         help="Require use of an API key for programmatic access to the API, unless the client also matches a fingerprint",
     )
     parser.add_argument(
+        "--hide-api",
+        default=DEFARGS['HIDE_API'],
+        action="store_true",
+        help="Hide the API request/response fields in the frontend",
+    )
+    parser.add_argument(
         "--under-attack",
         default=DEFARGS['UNDER_ATTACK'],
         action="store_true",

--- a/libretranslate/templates/index.html
+++ b/libretranslate/templates/index.html
@@ -296,6 +296,7 @@
 			</div>
 		</div>
 
+		{% if not hide_api %}
 		<div class="section no-pad-bot" v-if="translationType !== 'files'">
 			<div class="container">
 				<div class="row center">
@@ -318,6 +319,7 @@
 				</div>
 			</div>
 		</div>
+		{% endif %}
 		{% if web_version %}
 		<div class="section no-pad-bot">
 			<div class="container">


### PR DESCRIPTION
Assume you know for sure that only **non-tech users** will be using your LibreTranslate instance. In the best case, they may get confused what these input boxes mean, in the worst case, they are not using the tool because they don't know how to interpret these fields. In both cases, they use up space without being helpful.

Add PR adds a new CLI option `--hide-api` to hide the API request/response fields from the web interface. It defaults to `false` to preserve existing behavior.