### PR TITLE
healthcheck.py: Fail on non 200 status

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -12,4 +12,4 @@ response = requests.post(
     },
     timeout=60
 )
-# if server unavailable then requests with raise exception and healthcheck will fail
+response.raise_for_status() # if server unavailable then requests with raise exception and healthcheck will fail


### PR DESCRIPTION
This way the health check will also fail on HTTP 500 and similar status codes