### PR TITLE
Update index.html

### DIFF
--- a/libretranslate/templates/index.html
+++ b/libretranslate/templates/index.html
@@ -72,7 +72,7 @@
 					{% if get_api_key_link %}
 					<li><a href="{{ get_api_key_link }}">{{ _h("Get API Key") }}</a></li>
 					{% endif %}
-					<li><a href="https://github.com/LibreTranslate/LibreTranslate" rel="noopener noreferrer">{{ _h("GitHub") }}</a></li>
+					<li><a href="https://github.com/LibreTranslate/LibreTranslate" target="_blank" rel="noopener noreferrer">{{ _h("GitHub") }}</a></li>
 					{% if api_keys %}
 					<li><a class="noline" href="javascript:setApiKey()" title="{{ _h('Set API Key') }}" aria-label="{{ _h('Set API Key') }}"><i class="material-icons">vpn_key</i></a></li>
 					{% endif %}


### PR DESCRIPTION
Adding `target="_blank"`

This will allow any hosted LibreTranslate instance on HugginFace to open the Github link.

Check on : https://huggingface.co/spaces/Imsidag-community/LibreTranslate_Kabyle