### PR TITLE
Add tty: true to compose files for logging

### DIFF
--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -6,6 +6,7 @@ services:
       - "5000:5000"
     restart: unless-stopped
     command: --disable-web-ui
+    tty: true
     environment:
      - LT_API_KEYS_DB_PATH=/app/db/api_keys.db
      - LT_API_KEYS=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       timeout: 4s
       retries: 4
       start_period: 5s
+    tty: true
     ## Uncomment above command and define your args if necessary
     # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500
     ## Uncomment this section and the libretranslate_api_keys volume if you want to backup your API keys


### PR DESCRIPTION
The current version of the docker compose files is missing the `tty: true` config setting. Without this, logs are completely blank. I'm not sure why it's not mentioned anywhere in the documentation or why it was removed in newer commits, but this PR adds it back to avoid confusion.