### PR TITLE
Add `/health` endpoint for service health checks

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -520,6 +520,28 @@ def create_app(args):
                          "targets": model2iso(language_pairs.get(l.code, []))
                         } for l in languages])
 
+    @bp.get("/health")
+    @limiter.exempt
+    def health():
+        """
+        Health Check
+        ---
+        tags:
+          - misc
+        responses:
+          200:
+            description: Service is healthy
+            schema:
+              id: health-response
+              type: object
+              properties:
+                status:
+                  type: string
+                  description: Health status
+                  example: ok
+        """
+        return jsonify({"status": "ok"})
+
     # Add cors
     @bp.after_request
     def after_request(response):

--- a/libretranslate/tests/test_api/test_api_health.py
+++ b/libretranslate/tests/test_api/test_api_health.py
@@ -1,0 +1,11 @@
+def test_api_get_health(client):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json == {"status": "ok"}
+
+
+def test_api_health_must_fail_bad_request_type(client):
+    response = client.post("/health")
+
+    assert response.status_code == 405


### PR DESCRIPTION
## PR Summary
This PR addes a `/health` endpoint to provide a simple HTTP health check for LibreTranslate. Like other sevices, the endpoint returns `{"status": "ok"}` with a 200 status code and is exempt from rate limiting.

Fixes #826.