### PR TITLE
Update torch installation in Dockerfile to use version from pyproject.toml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 
 # Install package from source code, compile translations
 RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_locales.py \
-  && ./venv/bin/pip install torch==2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu \
+  && ./venv/bin/pip install torch==$(grep -o -m1 'torch.*;' pyproject.toml|sed 's/[^0-9.]//g') --extra-index-url https://download.pytorch.org/whl/cpu \
   && ./venv/bin/pip install "numpy<2" \
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge


### PR DESCRIPTION
Multiple torch installations causes the docker image to balloon. This should fix that. 