### PR TITLE
Update argos-translate to 1.10.0 to make compatible with Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "argostranslate ==1.9.6",
+    "argostranslate ==1.10.0",
     "Flask ==2.2.5",
     "flask-swagger ==0.2.14",
     "flask-swagger-ui ==4.11.1",


### PR DESCRIPTION
On Debian 13 GNOME:

Otherwise face `KeyError: 'default_dependencies'` in `stanza`:

```
libretranslate
```
<details>
<summary>Output:</summary>

```
/home/benjamin_loison/venv/lib/python3.13/site-packages/apscheduler/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution, DistributionNotFound
Running on http://127.0.0.1:5000
WARNING:waitress.queue:Task queue depth is 1
WARNING:waitress.queue:Task queue depth is 2
WARNING:waitress.queue:Task queue depth is 2
WARNING:waitress.queue:Task queue depth is 2
WARNING:waitress.queue:Task queue depth is 2
ERROR:libretranslate.app:Exception on /translate [POST]
Traceback (most recent call last):
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/flask/app.py", line 2529, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/libretranslate/app.py", line 404, in time_func
    return func(*a, **kw)
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/libretranslate/app.py", line 378, in func
    return f(*a, **kw)
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/libretranslate/app.py", line 831, in translate
    raise e
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/libretranslate/app.py", line 815, in translate
    hypotheses = translator.hypotheses(q, num_alternatives + 1)
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/argostranslate/translate.py", line 296, in hypotheses
    translated_paragraph = self.underlying.hypotheses(
        paragraph, num_hypotheses
    )
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/argostranslate/translate.py", line 173, in hypotheses
    apply_packaged_translation(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.pkg, paragraph, self.translator, num_hypotheses
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/argostranslate/translate.py", line 418, in apply_packaged_translation
    stanza_pipeline = stanza.Pipeline(
        lang=pkg.from_code,
    ...<3 lines>...
        logging_level="WARNING",
    )
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/stanza/pipeline/core.py", line 83, in __init__
    self.load_list = add_dependencies(resources, lang, self.load_list) if lang in resources else []
                     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/benjamin_loison/venv/lib/python3.13/site-packages/stanza/resources/common.py", line 213, in add_dependencies
    default_dependencies = resources[lang]['default_dependencies']
                           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'default_dependencies'
```
</details>

Personal notes: [Benjamin-Loison/LibreTranslate/issues/25](https://github.com/Benjamin-Loison/LibreTranslate/issues/25)