### PR TITLE
Fix torch version for Python < 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ dependencies = [
     "prometheus-client ==0.15.0",
     "polib ==1.1.1",
     "packaging ==23.1",
-    "torch ==2.4.0;python_version<'3.9'",
-    "torch ==2.5.0;python_version>='3.9'",
+    "torch ==2.4.0;python_version<'3.12'",
+    "torch ==2.5.0;python_version>='3.12'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Tries to reduce the Docker file size.

But the key problem is that we depend on stanza, which depends on torch. Ideally we should get rid of torch by converting all stanza models to ONNX (and get a nice performance boost in the process).