### PR TITLE
Update Docker Python base images to 3.11.14 bookworm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.11-slim-bullseye AS builder
+FROM python:3.11.14-slim-bookworm AS builder
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_lo
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 
-FROM python:3.11.11-slim-bullseye
+FROM python:3.11.14-slim-bookworm
 
 ARG with_models=false
 ARG models=""

--- a/docker/arm.Dockerfile
+++ b/docker/arm.Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/python:3.11.11-slim-bullseye as builder
+FROM arm64v8/python:3.11.14-slim-bookworm as builder
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN ./venv/bin/pip install Babel==2.12.1 && ./venv/bin/python scripts/compile_lo
   && ./venv/bin/pip install . \
   && ./venv/bin/pip cache purge
 
-FROM arm64v8/python:3.11.11-slim-bullseye
+FROM arm64v8/python:3.11.14-slim-bookworm
 
 ARG with_models=false
 ARG models=""

--- a/docker/root-with-sshd.Dockerfile
+++ b/docker/root-with-sshd.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.11-slim-bullseye AS builder
+FROM python:3.11.14-slim-bookworm AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN <<EOF
   ./venv/bin/pip cache purge
 EOF
 
-FROM python:3.11.11-slim-bullseye
+FROM python:3.11.14-slim-bookworm
 
 ARG with_models=false
 ARG models=""

--- a/docker/user-with-api-key.Dockerfile
+++ b/docker/user-with-api-key.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.11-slim-bullseye AS builder
+FROM python:3.11.14-slim-bookworm AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN <<EOF
   ./venv/bin/pip cache purge
 EOF
 
-FROM python:3.11.11-slim-bullseye
+FROM python:3.11.14-slim-bookworm
 
 ARG with_models=false
 ARG models=""


### PR DESCRIPTION
Switch Docker base images to Python v3.11.14 slim-bookworm because the official Python images no longer ship slim-bullseye. Keeps Python 3.11.12-3.11.14 security fixes (libexpat, tarfile filters, zip64, setuptools CVEs) on a supported Debian base.

Refs:
- https://www.python.org/downloads/release/python-31114/
- https://www.python.org/downloads/release/python-31113/
- https://www.python.org/downloads/release/python-31112/

GitHub Copilot Summary:

> This pull request updates all Dockerfiles to use a newer Python base image and a more recent Debian distribution. The changes ensure that the containers are built on Python 3.11.14 and Debian Bookworm (instead of Python 3.11.11 and Debian Bullseye), which provides improved security and compatibility.
> 
> **Base image and distribution upgrades:**
> 
> * Updated the base image in all Dockerfiles (`Dockerfile`, `arm.Dockerfile`, `root-with-sshd.Dockerfile`, `user-with-api-key.Dockerfile`) from `python:3.11.11-slim-bullseye` to `python:3.11.14-slim-bookworm` [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL1-R1) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL24-R24) [[3]](diffhunk://#diff-f8c4586ad758938392e13939d1f1565155465ff01a17c7f81f807e0cf8b9e248L1-R1) [[4]](diffhunk://#diff-f8c4586ad758938392e13939d1f1565155465ff01a17c7f81f807e0cf8b9e248L24-R24) [[5]](diffhunk://#diff-d82daf4b89b116a8d5d32634ffd9e552b30d2bcacba69bfb5a83d2e48c206ef9L1-R1) [[6]](diffhunk://#diff-d82daf4b89b116a8d5d32634ffd9e552b30d2bcacba69bfb5a83d2e48c206ef9L29-R29) [[7]](diffhunk://#diff-54234d2be395fd3a7393d72e3db2be0db06b8fbd35c1976206cb9601b7988d9cL1-R1) [[8]](diffhunk://#diff-54234d2be395fd3a7393d72e3db2be0db06b8fbd35c1976206cb9601b7988d9cL29-R29)
> * Updated the ARM Dockerfile to use `arm64v8/python:3.11.14-slim-bookworm` as the base image [[1]](diffhunk://#diff-f8c4586ad758938392e13939d1f1565155465ff01a17c7f81f807e0cf8b9e248L1-R1) [[2]](diffhunk://#diff-f8c4586ad758938392e13939d1f1565155465ff01a17c7f81f807e0cf8b9e248L24-R24)