### PR TITLE
Remove invalid settings in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     ## Uncomment this for logging in docker compose logs
     # tty: true
     ## Uncomment above command and define your args if necessary
-    # command: --ssl --ga-id MY-GA-ID --req-limit 100 --char-limit 500
+    ## Refer to the documentation for more information: https://docs.libretranslate.com/guides/installation/#arguments
+    # command: --ssl --req-limit 100 --char-limit 500
     ## Uncomment this section and the libretranslate_api_keys volume if you want to backup your API keys
     # environment:
     #   - LT_API_KEYS=true


### PR DESCRIPTION
This PR removes the deprecated `--ga-id` argument, as it is no longer supported in this version. This change prevents potential runtime errors for users who might miss the documentation update.