### PR TITLE
Bump `argostranslate` to version `1.10.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "argostranslate ==1.9.6",
+    "argostranslate ==1.10.0",
     "Flask ==2.2.5",
     "flask-swagger ==0.2.14",
     "flask-swagger-ui ==4.11.1",


### PR DESCRIPTION
Hi,
Bumped `argostranslate` version to fix build issue in MacOS while installing `argostranslate==1.9.6` on `python3.14.2`

<details>
<summary>Error Traceback</summary>

```
      Built libretranslate @ file:///Users/user/Projects/LibreTranslate
× Failed to build `sentencepiece==0.2.0`
├─▶ The build backend returned an error
╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

[stdout]
running bdist_wheel
running build
running build_py
copying src/sentencepiece/__init__.py -> build/lib.macosx-26.0-arm64-cpython-314/sentencepiece
copying src/sentencepiece/_version.py -> build/lib.macosx-26.0-arm64-cpython-314/sentencepiece
copying src/sentencepiece/sentencepiece_model_pb2.py -> build/lib.macosx-26.0-arm64-cpython-314/sentencepiece
copying src/sentencepiece/sentencepiece_pb2.py -> build/lib.macosx-26.0-arm64-cpython-314/sentencepiece
running build_ext
-- Configuring incomplete, errors occurred!

[stderr]
<string>:30: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/dist.py:289: UserWarning:
Unknown distribution option: 'test_suite'
      warnings.warn(msg)
/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/dist.py:765:
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

            ********************************************************************************
            Please consider removing the following classifiers in favor of a SPDX license expression:

            License :: OSI Approved :: Apache Software License

            See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
            ********************************************************************************

!!
      self._finalize_license_expression()
/bin/sh: pkg-config: command not found
CMake Error at CMakeLists.txt:15 (cmake_minimum_required):
      Compatibility with CMake < 3.5 has been removed from CMake.

      Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
      to tell CMake that the project requires at least <min> but has been updated
      to work with policies introduced by <max> or earlier.

      Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


./build_bundled.sh: line 22: nproc: command not found
Error: could not find CMAKE_PROJECT_NAME in Cache
Traceback (most recent call last):
      File "<string>", line 11, in <module>
      wheel_filename = backend.build_wheel("/Users/user/.cache/uv/builds-v0/.tmpvwzjWE", {}, None)
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/build_meta.py", line 436,
in build_wheel
      return _build(['bdist_wheel'])
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/build_meta.py", line 427,
in _build
      return self._build_with_temp_dir(
            ~~~~~~~~~~~~~~~~~~~~~~~~~^
            cmd,
            ^^^^
      ...<3 lines>...
            self._arbitrary_args(config_settings),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )
      ^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/build_meta.py", line 408,
in _build_with_temp_dir
      self.run_setup()
      ~~~~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/build_meta.py", line 518,
in run_setup
      super().run_setup(setup_script=setup_script)
      ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/build_meta.py", line 317,
in run_setup
      exec(code, locals())
      ~~~~^^^^^^^^^^^^^^^^
      File "<string>", line 169, in <module>
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/__init__.py", line 117, in
setup
      return distutils.core.setup(**attrs)  # type: ignore[return-value]
            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/core.py", line 186,
in setup
      return run_commands(dist)
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/core.py", line 202,
in run_commands
      dist.run_commands()
      ~~~~~~~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line
1002, in run_commands
      self.run_command(cmd)
      ~~~~~~~~~~~~~~~~^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/dist.py", line 1107, in
run_command
      super().run_command(command)
      ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line
1021, in run_command
      cmd_obj.run()
      ~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/command/bdist_wheel.py", line
370, in run
      self.run_command("build")
      ~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/cmd.py", line 357,
in run_command
      self.distribution.run_command(command)
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/dist.py", line 1107, in
run_command
      super().run_command(command)
      ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line
1021, in run_command
      cmd_obj.run()
      ~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/command/build.py",
line 135, in run
      self.run_command(cmd_name)
      ~~~~~~~~~~~~~~~~^^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/cmd.py", line 357,
in run_command
      self.distribution.run_command(command)
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/dist.py", line 1107, in
run_command
      super().run_command(command)
      ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line
1021, in run_command
      cmd_obj.run()
      ~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/command/build_ext.py", line
97, in run
      _build_ext.run(self)
      ~~~~~~~~~~~~~~^^^^^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/command/build_ext.py",
line 368, in run
      self.build_extensions()
      ~~~~~~~~~~~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/command/build_ext.py",
line 484, in build_extensions
      self._build_extensions_serial()
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/Users/user/.cache/uv/builds-v0/.tmp7NrNDD/lib/python3.14/site-packages/setuptools/_distutils/command/build_ext.py",
line 510, in _build_extensions_serial
      self.build_extension(ext)
      ~~~~~~~~~~~~~~~~~~~~^^^^^
      File "<string>", line 87, in build_extension
      File "/opt/homebrew/Cellar/python@3.14/3.14.2/Frameworks/Python.framework/Versions/3.14/lib/python3.14/subprocess.py",
line 419, in check_call
      raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['./build_bundled.sh', '0.2.0']' returned non-zero exit status 1.

hint: This usually indicates a problem with the package or the build environment.
help: `sentencepiece` (v0.2.0) was included because `libretranslate` (v1.8.3) depends on `argostranslate` (v1.9.6) which
      depends on `sentencepiece`
```
</details>
Related to :  google/sentencepiece/issues/932

Tx.