### PR TITLE
Add optional preloaded offline Docker image example

### DIFF
--- a/Dockerfile.preloaded
+++ b/Dockerfile.preloaded
@@ -1,0 +1,11 @@
+FROM libretranslate/libretranslate:latest
+
+USER root
+
+RUN mkdir -p /home/libretranslate/.local/share/argos-translate/packages
+
+COPY models/ /home/libretranslate/.local/share/argos-translate/packages/
+
+RUN chmod -R 755 /home/libretranslate/.local
+
+EXPOSE 5000

--- a/docker-compose.big.yml
+++ b/docker-compose.big.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+name: libretranslate-offline-ru-en-zh
+
+services:
+  libretranslate-offline:
+    container_name: libretranslate-offline-ru-en-zh
+    image: dvurechensky/libretranslate-offline-ru-en-zh:1.0
+
+    build:
+      context: .
+      dockerfile: Dockerfile.preloaded
+
+    ports:
+      - "5000:5000"
+
+    restart: unless-stopped
+
+    environment:
+      LT_UPDATE_MODELS: "false"
+      LT_LOAD_ONLY: "en,ru,zh"
+      LT_DEBUG: "false"
+      LT_REQ_LIMIT: "0"
+      LT_CHAR_LIMIT: "50000"
+
+    volumes:
+      - libretranslate_cache:/root/.cache
+      - libretranslate_db:/app/db
+
+    healthcheck:
+      test: ["CMD-SHELL", "python scripts/healthcheck.py"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+
+volumes:
+  libretranslate_cache:
+  libretranslate_db:

--- a/docs/preloaded-offline-image.md
+++ b/docs/preloaded-offline-image.md
@@ -1,0 +1,108 @@
+# Preloaded Offline Docker Image
+
+This is an optional deployment example for users who prefer preloaded models.
+
+This guide describes how to build a LibreTranslate Docker image with translation models already included inside the container.
+
+This is useful for environments where downloading models during startup is not preferred or unavailable.
+
+Examples:
+
+- offline servers
+- restricted corporate networks
+- air-gapped systems
+- faster first startup
+- predictable deployments
+
+---
+
+## Benefits
+
+Using a preloaded image provides:
+
+- no model downloads on first run
+- faster startup time
+- deterministic deployments
+- easier backup and migration
+- portable ready-to-run container images
+
+---
+
+## Folder Structure
+
+Create a local folder named:
+
+```text
+models/
+```
+
+Place Argos Translate model folders inside it.
+
+Example:
+
+```text
+models/
+ ├── translate-en_ru-1_9/
+ ├── translate-ru_en-1_9/
+ ├── translate-en_zh-1_9/
+ └── translate-zh_en-1_9/
+```
+
+---
+
+## Preloader Dockerfile
+
+Use the included Dockerfile: [Dockerfile.preloaded](../Dockerfile.preloaded)
+
+---
+
+## Compose Example
+
+Use the included file: [docker-compose.big.yml](../docker-compose.big.yml)
+
+---
+
+## Build Image
+
+```bash
+docker compose -f docker-compose.big.yml build
+```
+
+---
+
+## Run Container
+
+```bash
+docker compose -f docker-compose.big.yml up -d
+```
+
+---
+
+## Open Web UI
+
+```text
+http://localhost:5000
+```
+
+---
+
+## Notes
+
+- `LT_UPDATE_MODELS=false` disables downloading models during startup.
+- `LT_LOAD_ONLY` limits loaded languages to reduce memory usage.
+- You may include any supported language models.
+
+---
+
+## Example Use Cases
+
+- Russian / English / Chinese offline translator
+- Internal translation API
+- Local automation pipelines
+- Secure private infrastructure
+
+---
+
+## Disclaimer
+
+This is an optional deployment pattern and does not modify the default LibreTranslate behavior.


### PR DESCRIPTION
Hi team,

## Summary

This PR adds an optional deployment example for building LibreTranslate Docker images with preloaded translation models.

The goal is to help users who prefer container images that are ready to run immediately without downloading models during startup.

---

## Included Files

* `Dockerfile.preloaded`
* `docker-compose.big.yml`
* `docs/preloaded-offline-image.md`

---

## Use Cases

This may be useful for:

* offline environments
* restricted corporate networks
* air-gapped systems
* faster first startup
* predictable deployments
* easier backup and migration

---

## Notes

* This is an optional example only.
* Existing default behavior is unchanged.
* Users may include any supported language models in the `models/` folder.

---

## Reference Implementation

I also tested this workflow by publishing a sample preloaded image:

https://hub.docker.com/r/dvurechensky/libretranslate-offline-ru-en-zh

---

## Why

Some deployments prefer images with baked-in models instead of runtime downloads.

This example provides a simple reference implementation for that workflow.

---

Thanks for LibreTranslate and the project.
