### PR TITLE
fix: make Gunicorn worker timeout configurable via LT_TIMEOUT

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -53,5 +53,5 @@ if [[ -z "$ARGOS_CHUNK_TYPE" ]]; then
     export ARGOS_CHUNK_TYPE=MINISBD
 fi
 
-./venv/bin/gunicorn -c scripts/gunicorn_conf.py --workers $LT_THREADS --max-requests 250 --timeout 2400 --bind $BIND_ADDR:$LT_PORT 'wsgi:app()'
+./venv/bin/gunicorn -c scripts/gunicorn_conf.py --workers $LT_THREADS --max-requests 250 --timeout ${LT_TIMEOUT:-2400} --bind $BIND_ADDR:$LT_PORT 'wsgi:app()'
 


### PR DESCRIPTION
This PR makes the Gunicorn worker timeout configurable via an LT_TIMEOUT environment variable. Currently, large document translations (like heavy PDFs) can trigger a worker timeout and fail with a Cannot load /translate_file error because the timeout is hardcoded to 2400s.

This change allows users dealing with larger payloads to easily increase the timeout in their configurations, while safely defaulting to the original 2400 if the variable is not set.

For a future improvement, we might want to look into automatically chunking large PDFs or offloading them to a background task queue to prevent HTTP connection drops.

Fixes Issue: #966 

Changes:

Updated scripts/entrypoint.sh to accept ${LT_TIMEOUT:-2400}.