### PR TITLE
fix: improve single-word Korean translation via context seeding

### DIFF
--- a/libretranslate/app.py
+++ b/libretranslate/app.py
@@ -21,9 +21,8 @@ from argostranslatefiles.translatehtml import translate_html
 from werkzeug.exceptions import HTTPException
 from werkzeug.http import http_date
 from werkzeug.utils import secure_filename
-
 from libretranslate import flood, remove_translated_files, scheduler, secret, security, storage, cache
-from libretranslate.language import model2iso, iso2model, detect_languages, improve_translation_formatting, get_language_with_fallback
+from libretranslate.language import model2iso, iso2model, detect_languages, improve_translation_formatting, get_language_with_fallback , translate_with_seeding
 from libretranslate.locales import (
     _,
     _lazy,
@@ -830,9 +829,15 @@ def create_app(args):
                           translated_text = unescape(str(translate_html(translator, text)))
                           alternatives = [] # Not supported for html yet
                       else:
-                          hypotheses = translator.hypotheses(text, num_alternatives + 1)
-                          translated_text = unescape(improve_translation_formatting(text, hypotheses[0].value))
-                          alternatives = filter_unique([unescape(improve_translation_formatting(text, hypotheses[i].value)) for i in range(1, len(hypotheses))], translated_text)
+                          # Use seeding for short texts (1-2 words) when no alternatives requested
+                          if len(text.split()) <= 2 and num_alternatives == 0:
+                              translated_text = translate_with_seeding(text, src_lang.code, tgt_lang.code, translator)
+                              translated_text = unescape(improve_translation_formatting(text, translated_text))
+                              alternatives = []
+                          else:
+                              hypotheses = translator.hypotheses(text, num_alternatives + 1)
+                              translated_text = unescape(improve_translation_formatting(text, hypotheses[0].value))
+                              alternatives = filter_unique([unescape(improve_translation_formatting(text, hypotheses[i].value)) for i in range(1, len(hypotheses))], translated_text)
                     else:
                       translated_text = text # Cannot translate, send the original text back
                       alternatives = []
@@ -856,9 +861,15 @@ def create_app(args):
                       translated_text = unescape(str(translate_html(translator, q)))
                       alternatives = [] # Not supported for html yet
                   else:
-                      hypotheses = translator.hypotheses(q, num_alternatives + 1)
-                      translated_text = unescape(improve_translation_formatting(q, hypotheses[0].value))
-                      alternatives = filter_unique([unescape(improve_translation_formatting(q, hypotheses[i].value)) for i in range(1, len(hypotheses))], translated_text)
+                      # Use seeding for short texts (1-2 words) when no alternatives requested
+                      if len(q.split()) <= 2 and num_alternatives == 0:
+                          translated_text = translate_with_seeding(q, src_lang.code, tgt_lang.code, translator)
+                          translated_text = unescape(improve_translation_formatting(q, translated_text))
+                          alternatives = []
+                      else:
+                          hypotheses = translator.hypotheses(q, num_alternatives + 1)
+                          translated_text = unescape(improve_translation_formatting(q, hypotheses[0].value))
+                          alternatives = filter_unique([unescape(improve_translation_formatting(q, hypotheses[i].value)) for i in range(1, len(hypotheses))], translated_text)
                 else:
                   translated_text = q # Cannot translate, send the original text back
                   alternatives = []

--- a/libretranslate/language.py
+++ b/libretranslate/language.py
@@ -193,16 +193,15 @@ def translate_with_seeding(text, source_lang, target_lang, translator):
     
     # Step 1: Translate the template to get target-language pattern
     seed_translated = translator.translate(
-        SEED_TEMPLATE, source=source_lang, target=target_lang
+        SEED_TEMPLATE
     )
     # e.g., "사람이 말했다: %1"
     
     # Step 2: Translate template with actual word substituted
     seeded_input = SEED_TEMPLATE.replace("%1", text)
     seeded_translated = translator.translate(
-        seeded_input, source=source_lang, target=target_lang
+        seeded_input
     )
-    # e.g., "사람이 말했다 : 먹고"
     
     # Step 3: Regex match to extract just the translated word
     pattern = re.escape(seed_translated.replace("%1", "")).strip()

--- a/libretranslate/language.py
+++ b/libretranslate/language.py
@@ -1,4 +1,5 @@
 
+import re
 from functools import lru_cache
 
 from argostranslate import translate
@@ -180,3 +181,35 @@ def improve_translation_formatting(source, translation, improve_punctuation=True
 
     return translation
 
+
+def translate_with_seeding(text, source_lang, target_lang, translator):
+    """Workaround for poor single-word translations using context seeding."""
+    
+    # Only apply to short inputs (1-2 words)
+    if len(text.split()) > 2:
+        return translator.translate(text)
+
+    SEED_TEMPLATE = "The person said: %1"
+    
+    # Step 1: Translate the template to get target-language pattern
+    seed_translated = translator.translate(
+        SEED_TEMPLATE, source=source_lang, target=target_lang
+    )
+    # e.g., "사람이 말했다: %1"
+    
+    # Step 2: Translate template with actual word substituted
+    seeded_input = SEED_TEMPLATE.replace("%1", text)
+    seeded_translated = translator.translate(
+        seeded_input, source=source_lang, target=target_lang
+    )
+    # e.g., "사람이 말했다 : 먹고"
+    
+    # Step 3: Regex match to extract just the translated word
+    pattern = re.escape(seed_translated.replace("%1", "")).strip()
+    match = re.search(pattern + r"\s*(.+)", seeded_translated)
+    
+    if match:
+        return match.group(1).strip()
+    
+    # Fallback to direct translation if seeding didn't work
+    return translator.translate(text)

--- a/libretranslate/tests/test_api/test_api_translate.py
+++ b/libretranslate/tests/test_api/test_api_translate.py
@@ -59,3 +59,22 @@ def test_api_translate_missing_parameter(client):
     assert "error" in response_json
     assert response_json["error"] == "Invalid request: missing q parameter"
     assert response.status_code == 400
+
+
+
+
+def test_api_translate_rare_words(client):
+    # Test rare words that don't normally appear in daily speech
+    rare_words = ["defenestration", "quixotic", "serendipity"]
+    for word in rare_words:
+        response = client.post("/translate", data={
+            "q": word,
+            "source": "en",
+            "target": "es",
+            "format": "text"
+        })
+
+        response_json = json.loads(response.data)
+        assert "translatedText" in response_json
+        assert response.status_code == 200
+        assert len(response_json["translatedText"]) > 0

--- a/scripts/test_rare_words.py
+++ b/scripts/test_rare_words.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import json
 import ssl
 
 # Bypass SSL certificate verification for downloads (common macOS python issue)
@@ -26,82 +25,156 @@ RARE_WORDS = [
     "trenchant", "capricious", "laconic", "splendiferous", "apochromatic"
 ]
 
-TARGET_LANGS = ["es", "fr", "de", "it", "pt"]
+# Common everyday words used as a quick sanity check (seeded vs direct, Korean only)
+COMMON_WORDS = [
+    "eat", "run", "love", "sleep", "think",
+    "walk", "happy", "angry", "beautiful", "cold",
+    "fast", "house", "water", "dream", "friend",
+    "light", "dark", "strong", "kind", "brave"
+]
+
+TARGET_LANGS = ["es", "fr", "de", "it", "pt", "ko"]
+
+LANG_NAMES = {
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ko": "Korean",
+}
+
+
+def translate_direct(word, translator):
+    """Translate directly without seeding (raw model output)."""
+    try:
+        return translator.translate(word)
+    except Exception as e:
+        return f"[ERROR: {str(e)}]"
+
+
+def print_common_words_comparison(ko_translator):
+    """Quick sanity check: seeded vs direct on everyday words, Korean only."""
+    if ko_translator is None:
+        print("\nKorean translator not available; skipping common-words test.")
+        return
+
+    print(f"\n{'Word':<15} {'Seeded':<20} {'Direct':<20} {'Different?'}")
+    print("-" * 70)
+    for word in COMMON_WORDS:
+        seeded = translate_with_seeding(word, "en", "ko", ko_translator)
+        direct = translate_direct(word, ko_translator)
+        diff = "✅ DIFFERENT" if seeded.strip().lower() != direct.strip().lower() else "same"
+        print(f"{word:<15} {seeded:<20} {direct:<20} {diff}")
+
 
 def main():
-    print("Booting LibreTranslate and installing models for: en, es, fr, de, it, pt...")
-    # This downloads and installs packages if not present by using install_models=True
-    boot(load_only=["en", "es", "fr", "de", "it", "pt"], install_models=True)
+    from argostranslate import package as _pkg
+    installed_codes = {p.from_code for p in _pkg.get_installed_packages()} | \
+                      {p.to_code   for p in _pkg.get_installed_packages()}
+    needed = {"en", "es", "fr", "de", "it", "pt", "ko"}
+    needs_install = not needed.issubset(installed_codes)
+
+    print(f"Installed lang codes: {sorted(installed_codes)}")
+    if needs_install:
+        missing = needed - installed_codes
+        print(f"Missing models for: {missing} — downloading...")
+        boot(load_only=["en", "es", "fr", "de", "it", "pt", "ko"], install_models=True)
+    else:
+        print("All models already installed — skipping download.")
+        boot(load_only=["en", "es", "fr", "de", "it", "pt", "ko"])
 
     languages = load_languages()
     src_lang = get_language_with_fallback("en", languages)
-    
+
     if src_lang is None:
         print("Error: English language model not found.")
         sys.exit(1)
 
+    # Pre-fetch translators for all target languages
+    translators = {}
+    for lang_code in TARGET_LANGS:
+        tgt_lang = get_language_with_fallback(lang_code, languages)
+        if tgt_lang is None:
+            print(f"  WARNING: Model for '{lang_code}' not found.")
+            translators[lang_code] = None
+        else:
+            t = src_lang.get_translation(tgt_lang)
+            if t is None:
+                print(f"  WARNING: No translator found for en→{lang_code}.")
+            translators[lang_code] = t
+
+    # ----------------------------------------------------------------
+    # Build results: for each word, store seeded + direct per language
+    # ----------------------------------------------------------------
     results = []
 
-    print(f"Translating {len(RARE_WORDS)} rare words...")
+    print(f"\nTranslating {len(RARE_WORDS)} rare words (seeded + direct) across {len(TARGET_LANGS)} languages...\n")
     for idx, word in enumerate(RARE_WORDS, 1):
-        row = {"#": idx, "English Word": word}
+        row = {"#": idx, "word": word}
         for lang_code in TARGET_LANGS:
-            tgt_lang = get_language_with_fallback(lang_code, languages)
-            if tgt_lang is None:
-                row[lang_code] = "[N/A - lang model missing]"
-                continue
-            
-            translator = src_lang.get_translation(tgt_lang)
-            if translator is None:
-                row[lang_code] = "[N/A - translator missing]"
-                continue
-            
-            try:
-                translated = translate_with_seeding(word, "en", lang_code, translator)
-                row[lang_code] = translated
-            except Exception as e:
-                row[lang_code] = f"[ERROR: {str(e)}]"
-        
+            t = translators.get(lang_code)
+            if t is None:
+                row[f"{lang_code}_seeded"] = "[N/A]"
+                row[f"{lang_code}_direct"] = "[N/A]"
+            else:
+                row[f"{lang_code}_seeded"] = translate_with_seeding(word, "en", lang_code, t)
+                row[f"{lang_code}_direct"] = translate_direct(word, t)
         results.append(row)
-        print(f"[{idx}/{len(RARE_WORDS)}] Translated '{word}'")
+        print(f"[{idx:2d}/50] {word}")
 
-    # Generate Markdown Table
-    headers = ["#", "English Word", "Spanish (es)", "French (fr)", "German (de)", "Italian (it)", "Portuguese (pt)"]
-    markdown_lines = []
-    markdown_lines.append("| " + " | ".join(headers) + " |")
-    markdown_lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
-
-    for row in results:
-        line_vals = [
-            str(row["#"]),
-            f"**{row['English Word']}**",
-            row.get("es", ""),
-            row.get("fr", ""),
-            row.get("de", ""),
-            row.get("it", ""),
-            row.get("pt", "")
-        ]
-        markdown_lines.append("| " + " | ".join(line_vals) + " |")
-
-    markdown_table = "\n".join(markdown_lines)
-    
-    # Write report file
+    # ----------------------------------------------------------------
+    # Write the main full comparison table
+    # ----------------------------------------------------------------
     report_dir = "/Users/bipinkumarrai/.gemini/antigravity/brain/309572f0-b6b7-4ee7-a934-895f54f1fc30"
     os.makedirs(report_dir, exist_ok=True)
     report_path = os.path.join(report_dir, "rare_words_results.md")
-    
+
     with open(report_path, "w", encoding="utf-8") as f:
         f.write("# Rare Words Translation Report\n\n")
-        f.write("This report presents the translation of 50 English words that don't normally appear in daily speech, across Spanish, French, German, Italian, and Portuguese.\n\n")
-        f.write("## Methodology\n")
-        f.write("Translations were evaluated using LibreTranslate's core translation engine with context-seeding applied to improve single-word translations.\n\n")
-        f.write("## Results\n\n")
-        f.write(markdown_table)
+        f.write("Translation of 50 rare English words across **Spanish, French, German, Italian, Portuguese, and Korean**.\n\n")
+        f.write("Each language has two sub-columns: **Seeded** (context-seeding workaround) vs **Direct** (raw model output).\n\n")
+        f.write("---\n\n")
+
+        # ------- Per-language comparison tables --------
+        for lang_code in TARGET_LANGS:
+            lang_name = LANG_NAMES[lang_code]
+            f.write(f"## {lang_name} ({lang_code})\n\n")
+            f.write(f"| # | English Word | Seeded | Direct | Changed? |\n")
+            f.write(f"| --- | --- | --- | --- | --- |\n")
+            for row in results:
+                seeded = row[f"{lang_code}_seeded"]
+                direct = row[f"{lang_code}_direct"]
+                changed = "✅" if seeded.strip().lower() != direct.strip().lower() else "—"
+                f.write(f"| {row['#']} | **{row['word']}** | {seeded} | {direct} | {changed} |\n")
+            f.write("\n")
+
+        # ------- Full overview table (seeded only) --------
+        f.write("---\n\n")
+        f.write("## Full Overview (Seeded Translations)\n\n")
+        headers = ["#", "English Word"] + [f"{LANG_NAMES[lc]} ({lc})" for lc in TARGET_LANGS]
+        f.write("| " + " | ".join(headers) + " |\n")
+        f.write("| " + " | ".join(["---"] * len(headers)) + " |\n")
+        for row in results:
+            vals = [str(row["#"]), f"**{row['word']}**"] + [row[f"{lc}_seeded"] for lc in TARGET_LANGS]
+            f.write("| " + " | ".join(vals) + " |\n")
         f.write("\n")
 
-    print(f"\nReport generated successfully at: {report_path}")
-    print("Printing results to stdout:\n")
-    print(markdown_table)
+    print(f"\n✅ Report written to: {report_path}")
+
+    # Also print a quick Korean comparison to stdout
+    print("\n--- Korean: Seeded vs Direct (first 20 words) ---\n")
+    print(f"{'Word':<35} {'Seeded':<30} {'Direct':<30} {'Different?'}")
+    print("-" * 105)
+    for row in results[:20]:
+        s = row["ko_seeded"]
+        d = row["ko_direct"]
+        diff = "YES ✅" if s.strip().lower() != d.strip().lower() else "same"
+        print(f"{row['word']:<35} {s:<30} {d:<30} {diff}")
+
+    # Quick sanity check on everyday words, reusing the Korean translator built above
+    print_common_words_comparison(translators.get("ko"))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test_rare_words.py
+++ b/scripts/test_rare_words.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import json
+import ssl
+
+# Bypass SSL certificate verification for downloads (common macOS python issue)
+ssl._create_default_https_context = ssl._create_unverified_context
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from libretranslate.init import boot
+from libretranslate.language import load_languages, get_language_with_fallback, translate_with_seeding
+
+# Define 50 rare words that don't normally appear in daily speech
+RARE_WORDS = [
+    "floccinaucinihilipilification", "antidisestablishmentarianism", "defenestration", "quixotic", "synecdoche",
+    "serendipity", "petrichor", "obfuscate", "cacophony", "ephemeral",
+    "soliloquy", "juxtaposition", "wanderlust", "superfluous", "garrulous",
+    "pulchritudinous", "schadenfreude", "onomatopoeia", "zeitgeist", "verisimilitude",
+    "fastidious", "esoteric", "anachronistic", "dichotomy", "epiphany",
+    "ubiquitous", "pernicious", "visceral", "surreptitious", "quintessential",
+    "recalcitrant", "mellifluous", "plethora", "susurrus", "panacea",
+    "liminal", "terpsichorean", "valetudinarian", "hegemony", "pejorative",
+    "paradigmatic", "mercurial", "grandiloquent", "inchoate", "sycophant",
+    "trenchant", "capricious", "laconic", "splendiferous", "apochromatic"
+]
+
+TARGET_LANGS = ["es", "fr", "de", "it", "pt"]
+
+def main():
+    print("Booting LibreTranslate and installing models for: en, es, fr, de, it, pt...")
+    # This downloads and installs packages if not present by using install_models=True
+    boot(load_only=["en", "es", "fr", "de", "it", "pt"], install_models=True)
+
+    languages = load_languages()
+    src_lang = get_language_with_fallback("en", languages)
+    
+    if src_lang is None:
+        print("Error: English language model not found.")
+        sys.exit(1)
+
+    results = []
+
+    print(f"Translating {len(RARE_WORDS)} rare words...")
+    for idx, word in enumerate(RARE_WORDS, 1):
+        row = {"#": idx, "English Word": word}
+        for lang_code in TARGET_LANGS:
+            tgt_lang = get_language_with_fallback(lang_code, languages)
+            if tgt_lang is None:
+                row[lang_code] = "[N/A - lang model missing]"
+                continue
+            
+            translator = src_lang.get_translation(tgt_lang)
+            if translator is None:
+                row[lang_code] = "[N/A - translator missing]"
+                continue
+            
+            try:
+                translated = translate_with_seeding(word, "en", lang_code, translator)
+                row[lang_code] = translated
+            except Exception as e:
+                row[lang_code] = f"[ERROR: {str(e)}]"
+        
+        results.append(row)
+        print(f"[{idx}/{len(RARE_WORDS)}] Translated '{word}'")
+
+    # Generate Markdown Table
+    headers = ["#", "English Word", "Spanish (es)", "French (fr)", "German (de)", "Italian (it)", "Portuguese (pt)"]
+    markdown_lines = []
+    markdown_lines.append("| " + " | ".join(headers) + " |")
+    markdown_lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+
+    for row in results:
+        line_vals = [
+            str(row["#"]),
+            f"**{row['English Word']}**",
+            row.get("es", ""),
+            row.get("fr", ""),
+            row.get("de", ""),
+            row.get("it", ""),
+            row.get("pt", "")
+        ]
+        markdown_lines.append("| " + " | ".join(line_vals) + " |")
+
+    markdown_table = "\n".join(markdown_lines)
+    
+    # Write report file
+    report_dir = "/Users/bipinkumarrai/.gemini/antigravity/brain/309572f0-b6b7-4ee7-a934-895f54f1fc30"
+    os.makedirs(report_dir, exist_ok=True)
+    report_path = os.path.join(report_dir, "rare_words_results.md")
+    
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write("# Rare Words Translation Report\n\n")
+        f.write("This report presents the translation of 50 English words that don't normally appear in daily speech, across Spanish, French, German, Italian, and Portuguese.\n\n")
+        f.write("## Methodology\n")
+        f.write("Translations were evaluated using LibreTranslate's core translation engine with context-seeding applied to improve single-word translations.\n\n")
+        f.write("## Results\n\n")
+        f.write(markdown_table)
+        f.write("\n")
+
+    print(f"\nReport generated successfully at: {report_path}")
+    print("Printing results to stdout:\n")
+    print(markdown_table)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
Single-word Korean translations return low-confidence/wrong results (issue #828).

## Solution
Implements the context-seeding workaround suggested by @pierotofy:
1. Translate a seed template `The person said: %1` to get the target-language pattern
2. Substitute the actual word and translate again
3. Regex-extract just the translated word from the result

Falls back to direct translation if regex doesn't match.


Closes #828