### PR TITLE
ci: pin jlumbroso/free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -45,7 +45,7 @@ jobs:
           TAG: ${{ startsWith(github.ref, 'refs/tags/') && steps.get-variables.outputs.version || 'latest' }}
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB


### PR DESCRIPTION
### What
Pin `jlumbroso/free-disk-space@main` → `54081f1…` in `publish-docker.yml` (tag kept in a trailing comment).

### Why
`@main` is a moving reference. This use sits in the [publish-docker job](https://github.com/LibreTranslate/LibreTranslate/blob/9d2cbe337d7271eab43a9ca7c3b0d1471ba2aa6e/.github/workflows/publish-docker.yml), which logs in to DockerHub (`DOCKERHUB_TOKEN`) and does `push: true`. If the action's `main` were
moved (compromise or an accidental change), the new code would run in a job holding registry push
credentials — the class of issue behind the 2025 `tj-actions/changed-files` incident.

### Scope / safety
- Behaviour unchanged — the SHA is the current tip of the action's `main`. Signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>
